### PR TITLE
chore: upgrade openmls and hpke-rs to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -97,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array 0.4.10",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +113,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -126,7 +135,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -148,10 +157,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "const-oid"
@@ -167,7 +182,7 @@ checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -175,6 +190,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -228,6 +252,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array 0.4.10",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,19 +271,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -290,10 +347,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -314,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -337,7 +404,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -360,7 +427,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -406,6 +473,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -508,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -588,17 +661,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "hpke-rs"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "hpke-rs-crypto",
- "hpke-rs-libcrux",
+ "hpke-rs-libcrux 0.6.1 (git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384)",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
@@ -612,8 +684,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "rand_core 0.9.5",
  "zeroize",
@@ -631,7 +702,24 @@ dependencies = [
  "libcrux-hkdf",
  "libcrux-kem",
  "libcrux-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.0",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-libcrux"
+version = "0.6.1"
+source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
+dependencies = [
+ "hpke-rs-crypto",
+ "libcrux-aead",
+ "libcrux-ecdh",
+ "libcrux-hkdf",
+ "libcrux-kem",
+ "libcrux-traits",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_core 0.10.0",
  "zeroize",
@@ -640,14 +728,14 @@ dependencies = [
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
  "hpke-rs-crypto",
  "k256",
+ "ml-kem",
  "p256",
  "p384",
  "rand 0.8.5",
@@ -656,7 +744,8 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2",
  "subtle",
- "x25519-dalek",
+ "x-wing",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -681,6 +770,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "ctutils",
  "typenum",
 ]
 
@@ -795,12 +894,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -822,9 +921,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -846,7 +945,27 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -918,7 +1037,7 @@ checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -986,7 +1105,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -1011,7 +1130,7 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "tls_codec",
 ]
 
@@ -1086,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -1125,12 +1244,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
 dependencies = [
  "const-oid",
- "hybrid-array",
+ "hybrid-array 0.3.1",
  "num-traits",
  "pkcs8",
  "rand_core 0.6.4",
- "sha3",
+ "sha3 0.10.8",
  "signature",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04437cb1a66c0b78740927b76cc61f218344b9f6ef3dd430e283274a718ef0e9"
+dependencies = [
+ "hybrid-array 0.4.10",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.0",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164eb3faeaecbd14b0b2a917c1b4d0c035097a9c559b0bed85c2cdd032bc8faa"
+dependencies = [
+ "ctutils",
+ "hybrid-array 0.4.10",
+ "num-traits",
 ]
 
 [[package]]
@@ -1182,7 +1325,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "log",
  "openmls_libcrux_crypto",
@@ -1200,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1216,11 +1359,11 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
- "hpke-rs-libcrux",
+ "hpke-rs-libcrux 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcrux-aead",
  "libcrux-ed25519",
  "libcrux-hkdf",
@@ -1229,7 +1372,7 @@ dependencies = [
  "libcrux-traits",
  "openmls_memory_storage",
  "openmls_traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "tls_codec",
 ]
@@ -1237,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "hex",
  "log",
@@ -1250,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1276,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "log",
  "openmls_traits",
@@ -1289,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
 dependencies = [
  "serde",
  "tls_codec",
@@ -1352,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -1362,7 +1505,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1374,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1487,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1497,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
  "rand_core 0.10.0",
@@ -1789,8 +1932,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1799,8 +1942,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -1815,7 +1968,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2029,7 +2182,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2110,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2123,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2133,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2146,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2315,15 +2468,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x-wing"
+version = "0.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d0d5f4d1f26b9b9e7477af1d3bef960e1d1fb64edab7912fde472a8a8432e"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "rand_core 0.10.0",
+ "sha3 0.11.0",
+ "x25519-dalek 3.0.0-pre.6",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "rand_core 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apqmls"
+version = "0.1.0"
+dependencies = [
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_memory_storage",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "serde",
+ "tap",
+ "thiserror",
+ "tls_codec",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,21 +762,6 @@ dependencies = [
  "x-wing",
  "x25519-dalek 2.0.1",
  "zeroize",
-]
-
-[[package]]
-name = "hpqmls"
-version = "0.1.0"
-dependencies = [
- "openmls",
- "openmls_basic_credential",
- "openmls_memory_storage",
- "openmls_rust_crypto",
- "openmls_traits",
- "serde",
- "tap",
- "thiserror",
- "tls_codec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -258,7 +258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array 0.4.10",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -544,7 +544,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -667,10 +667,10 @@ dependencies = [
 [[package]]
 name = "hpke-rs"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
+source = "git+https://github.com/cryspen/hpke-rs?rev=eeeb9ed4204b608f257ec69166e67e25ebe8c8bd#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "hpke-rs-crypto",
- "hpke-rs-libcrux 0.6.1 (git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384)",
+ "hpke-rs-libcrux 0.6.1 (git+https://github.com/cryspen/hpke-rs?rev=eeeb9ed4204b608f257ec69166e67e25ebe8c8bd)",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
+source = "git+https://github.com/cryspen/hpke-rs?rev=eeeb9ed4204b608f257ec69166e67e25ebe8c8bd#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "rand_core 0.9.5",
  "zeroize",
@@ -704,14 +704,14 @@ dependencies = [
  "libcrux-traits",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
+source = "git+https://github.com/cryspen/hpke-rs?rev=eeeb9ed4204b608f257ec69166e67e25ebe8c8bd#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "hpke-rs-crypto",
  "libcrux-aead",
@@ -721,14 +721,14 @@ dependencies = [
  "libcrux-traits",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
+source = "git+https://github.com/cryspen/hpke-rs?rev=eeeb9ed4204b608f257ec69166e67e25ebe8c8bd#eeeb9ed4204b608f257ec69166e67e25ebe8c8bd"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -740,7 +740,7 @@ dependencies = [
  "p384",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "sha2",
  "subtle",
@@ -965,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
  "crypto-common 0.2.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -976,9 +976,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libcrux-aead"
@@ -1037,7 +1037,7 @@ checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "tls_codec",
 ]
 
@@ -1205,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "hybrid-array 0.4.10",
  "kem",
  "module-lattice",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha3 0.11.0",
 ]
 
@@ -1325,7 +1325,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "log",
  "openmls_libcrux_crypto",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -1372,7 +1372,7 @@ dependencies = [
  "libcrux-traits",
  "openmls_memory_storage",
  "openmls_traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "tls_codec",
 ]
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "hex",
  "log",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "log",
  "openmls_traits",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?branch=dima%2Fpost-quantum-support#906389d24fdaa7a30d2db46a79c49690f36ee117"
+source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
 dependencies = [
  "serde",
  "tls_codec",
@@ -1630,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1645,7 +1645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2475,7 +2475,7 @@ checksum = "e17d0d5f4d1f26b9b9e7477af1d3bef960e1d1fb64edab7912fde472a8a8432e"
 dependencies = [
  "kem",
  "ml-kem",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha3 0.11.0",
  "x25519-dalek 3.0.0-pre.6",
 ]
@@ -2499,7 +2499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,25 +38,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "async-trait"
@@ -83,15 +77,15 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -104,15 +98,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -120,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
@@ -167,9 +161,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-models"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94950e87ea550d6d68f1993f3e7bebc8cb7235157bff84337d46195c3aa0b3f0"
+checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
  "hax-lib",
  "pastey",
@@ -224,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -282,11 +276,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -414,9 +409,15 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -440,25 +441,39 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -484,33 +499,33 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "hax-lib"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf40682e31dc3961209a4657f6fe7c412879b59f212bac3d14bd7ece5af76a3"
+checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -519,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33a5a4ff169bcc4e9189f4bace3ed22d03fcd8e52eee90a00b7b1e2621cb490"
+checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -532,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39dc59c01c2eec9bce75698c4f9ca01d11759ace2a28e1691b66fb0008c6a21"
+checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -578,61 +593,71 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs"
-version = "0.3.0"
-source = "git+https://github.com/kkohbrok/hpke-rs?rev=24ee889487d954ce2c1f3d8dfd677ad07bfa38be#24ee889487d954ce2c1f3d8dfd677ad07bfa38be"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "serde",
+ "subtle",
  "tls_codec",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.3.0"
-source = "git+https://github.com/kkohbrok/hpke-rs?rev=24ee889487d954ce2c1f3d8dfd677ad07bfa38be#24ee889487d954ce2c1f3d8dfd677ad07bfa38be"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+ "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
-version = "0.3.0"
-source = "git+https://github.com/kkohbrok/hpke-rs?rev=24ee889487d954ce2c1f3d8dfd677ad07bfa38be#24ee889487d954ce2c1f3d8dfd677ad07bfa38be"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
 dependencies = [
  "hpke-rs-crypto",
- "libcrux-chacha20poly1305",
+ "libcrux-aead",
  "libcrux-ecdh",
  "libcrux-hkdf",
  "libcrux-kem",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "libcrux-traits",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.0",
+ "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-rust-crypto"
-version = "0.3.0"
-source = "git+https://github.com/kkohbrok/hpke-rs?rev=24ee889487d954ce2c1f3d8dfd677ad07bfa38be#24ee889487d954ce2c1f3d8dfd677ad07bfa38be"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
  "hpke-rs-crypto",
  "k256",
- "ml-kem",
  "p256",
  "p384",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.0",
  "rand_core 0.6.4",
  "sha2",
+ "subtle",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -641,21 +666,13 @@ version = "0.1.0"
 dependencies = [
  "openmls",
  "openmls_basic_credential",
+ "openmls_memory_storage",
  "openmls_rust_crypto",
  "openmls_traits",
  "serde",
  "tap",
- "thiserror 2.0.16",
+ "thiserror",
  "tls_codec",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -669,12 +686,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -682,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -695,11 +713,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -710,48 +727,50 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -776,12 +795,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -795,15 +816,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -821,55 +842,79 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
-name = "kem"
-version = "0.3.0-pre.0"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
-dependencies = [
- "rand_core 0.6.4",
- "zeroize",
-]
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libcrux-aead"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13297ce29869a5c0edab0378837b0fc5f88bf99a843712d9201c3b1150b3b476"
+dependencies = [
+ "libcrux-aesgcm",
+ "libcrux-chacha20poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-aesgcm"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f2a019dab4097585a7d4f5b9deebe46cd1e628b16a5bc4cb0ce35e1da334e6"
+dependencies = [
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.3"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b318f5f2b32dfbfd27d1c5a3201d27b2ac7a4b4a4bf15ea754a385e6c294c5"
+checksum = "cc08d044676af21343b32b988411fa98dbb5cf65a03c9df478ced221bbdfdb1b"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-curve25519"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5514645ba1ee6c55dd71d62a50cc37ad8aab3f956826001aa8dad17482655c46"
+checksum = "bb1e5fd8476a6ed609d24ef42aee5ab6f99f7c65d054f92412da9f499e423299"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-ecdh"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fa67cad871d7be9175141b23a174b77536b039945c91b6a5a6d697acd6371"
+checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
@@ -877,29 +922,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcrux-hacl-rs"
-version = "0.0.3"
+name = "libcrux-ed25519"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1134af11da3f24ae8d1a7e2b60ee871c9e3ffd3d8857deaeebab8088b005addd"
+checksum = "835919315b7042fe9e03b6458efe0db94bf2aa7b873934dbee5b5463a8124b43"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "libcrux-hacl-rs"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
 dependencies = [
  "libcrux-macros",
 ]
 
 [[package]]
 name = "libcrux-hkdf"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7a54a1b453200e8a18205ffbecbb0fee0cce9ec8d0bd635898b7eb2879ac06"
+checksum = "8c1a89ca0c89be3a268a921e47105fb7873badf7267f5e3ebf4ea46baedd73ef"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-hmac",
+ "libcrux-secrets",
 ]
 
 [[package]]
 name = "libcrux-hmac"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743cdf6149a46b2cd5f62bea237a7c57011e85055486fc031513e1261cc6692e"
+checksum = "8a7a242707d65960770bd7e14e4f18a92bdf0b967777dd404887db8d087a643b"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -908,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3b41dcbc21a5fb7efbbb5af7405b2e79c4bfe443924e90b13afc0080318d31"
+checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
 dependencies = [
  "core-models",
  "hax-lib",
@@ -918,12 +976,14 @@ dependencies = [
 
 [[package]]
 name = "libcrux-kem"
-version = "0.0.3"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefe0e9579f058b99995cbaf918de3cbab90c4d2dde544fe75247fb027ff5af9"
+checksum = "12631592f491d22fd1a176d32b2c6edfb673998fd3987e9d95f8fa79ad2a737b"
 dependencies = [
+ "libcrux-curve25519",
  "libcrux-ecdh",
  "libcrux-ml-kem",
+ "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
  "rand 0.9.2",
@@ -941,43 +1001,47 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ml-kem"
-version = "0.0.3"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d368d3e8d6a74e277178d54921eca112a1e6b7837d7d8bc555091acb5d817f5"
+checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
  "libcrux-platform",
  "libcrux-secrets",
  "libcrux-sha3",
+ "libcrux-traits",
  "rand 0.9.2",
+ "tls_codec",
 ]
 
 [[package]]
 name = "libcrux-p256"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00d21690ebcc7ce1f242e6c4bdadfd8529f9cf2d7b961c0344c9bcb2c82f78f"
+checksum = "f4778ba25cb08bb8a96bd100e19ed9aecf78337198fd176036e21042b2dd99bc"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
+ "libcrux-secrets",
  "libcrux-sha2",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-platform"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a2901c5a92bb236cacd3d16bd6654b7f3471eb417bedab85f6225060cd4a03"
+checksum = "02491808ee5b9db8cb65fad64ae0be812db64beef179d945c00c7787dc7dfcf9"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -985,18 +1049,18 @@ dependencies = [
 
 [[package]]
 name = "libcrux-secrets"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332737e629fe6ba7547f5c0f90559eac865d5dbecf98138ffae8f16ab8cbe33f"
+checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
 dependencies = [
  "hax-lib",
 ]
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91eed3bb0ae073f46ae03c83318013fba6e3302bf3292639417b68e908fec4bf"
+checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1005,29 +1069,31 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.3"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d95de4257eafdfaf3bffecadb615219b0ca920c553722b3646d32dde76c797"
+checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
  "libcrux-platform",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-traits"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cdbf9591a39f04d6da6b9bad51ac58378604a80708c2173dadf92029891b9e2"
+checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
+ "libcrux-secrets",
  "rand 0.9.2",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1036,21 +1102,21 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ml-dsa"
@@ -1059,24 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
 dependencies = [
  "const-oid",
- "hybrid-array 0.3.1",
+ "hybrid-array",
  "num-traits",
  "pkcs8",
  "rand_core 0.6.4",
  "sha3",
  "signature",
-]
-
-[[package]]
-name = "ml-kem"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97befee0c869cb56f3118f49d0f9bb68c9e3f380dec23c1100aedc4ec3ba239a"
-dependencies = [
- "hybrid-array 0.2.3",
- "kem",
- "rand_core 0.6.4",
- "sha3",
 ]
 
 [[package]]
@@ -1091,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1115,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opaque-debug"
@@ -1127,25 +1181,26 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.7.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.8.1"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "log",
+ "openmls_libcrux_crypto",
  "openmls_memory_storage",
  "openmls_sqlite_storage",
  "openmls_traits",
  "rayon",
  "serde",
  "serde_bytes",
- "thiserror 2.0.16",
+ "thiserror",
  "tls_codec",
  "zeroize",
 ]
 
 [[package]]
 name = "openmls_basic_credential"
-version = "0.4.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.5.0"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1155,25 +1210,47 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls_libcrux_crypto"
+version = "0.3.1"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
+dependencies = [
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-libcrux",
+ "libcrux-aead",
+ "libcrux-ed25519",
+ "libcrux-hkdf",
+ "libcrux-hmac",
+ "libcrux-sha2",
+ "libcrux-traits",
+ "openmls_memory_storage",
+ "openmls_traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "tls_codec",
 ]
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.4.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.5.0"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "hex",
  "log",
  "openmls_traits",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror",
 ]
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.4.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.5.1"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1192,27 +1269,27 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror",
  "tls_codec",
 ]
 
 [[package]]
 name = "openmls_sqlite_storage"
-version = "0.1.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.2.0"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "log",
  "openmls_traits",
  "refinery",
  "rusqlite",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "openmls_traits"
-version = "0.4.0"
-source = "git+https://github.com/openmls/openmls.git?branch=konrad%2Fhpqmls_dep_branch#e06cd664baf69645a5db2e3119a1ca5a0b8a7a82"
+version = "0.5.0"
+source = "git+https://github.com/boxdot/openmls.git?branch=konrad%2Fhpqmls_dep_branch#8b72148733ee7e437ed35153e894bc2d0aa3b63e"
 dependencies = [
  "serde",
  "tls_codec",
@@ -1244,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1304,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1324,6 +1401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1359,18 +1446,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1380,6 +1467,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1399,7 +1492,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1419,7 +1522,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1428,17 +1541,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -1462,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.16"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba5d693abf62492c37268512ff35b77655d2e957ca53dab85bf993fe9172d15"
+checksum = "52c427f2572afe5c6cbfa2b1bf40071c89bf1a8539e958ea582842f6f38dcfae"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -1472,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.8.16"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a83581f18c1a4c3a6ebd7a174bdc665f17f618d79f7edccb6a0ac67e660b319"
+checksum = "702655abfc67f93a6f735e9fa4ace7d2e580633f8961f28acbfd7583ddce936c"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1483,7 +1602,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "siphasher",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
  "toml",
  "url",
@@ -1492,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.8.16"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c225407d8e52ef8cf094393781ecda9a99d6544ec28d90a6915751de259264"
+checksum = "5145756cdf293b5089dc6b4f103f1a1229cc55d67082c866f8c8289531c4b983"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1506,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1518,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1529,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -1545,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1571,12 +1690,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1603,15 +1716,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1629,18 +1742,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1649,15 +1762,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1708,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1730,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -1742,9 +1855,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1770,38 +1883,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
-dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1810,30 +1903,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1841,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1914,15 +2007,21 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -1936,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1954,11 +2053,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1992,28 +2091,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wasip2",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2023,24 +2122,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2048,24 +2133,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2079,39 +2198,121 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -2127,11 +2328,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2139,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2151,18 +2351,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2171,18 +2371,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2192,18 +2392,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2212,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2223,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2234,11 +2434,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 [package]
-name = "hpqmls"
+name = "apqmls"
+description = "Amortized Post-Quantum MLS Combiner"
+authors = ["Phoenix R&D GmbH <hello@phnx.im>"]
 version = "0.1.0"
 edition = "2024"
+license = "AGPL-3.0-or-later"
 
 [dependencies]
 openmls = { git = "https://github.com/openmls/openmls.git", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,20 @@ tls_codec = "0.4.2"
 openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git" }
 
 [patch."https://github.com/openmls/openmls.git"]
-openmls = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
-openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
-openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
-openmls_traits = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
-openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+# feat: Post-Quantum Cryptography support (ML-KEM + ML-DSA)
+# <https://github.com/openmls/openmls/pull/1994>
+openmls = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
+openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
+openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
+openmls_traits = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
+openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
 
 [patch.crates-io]
-hpke-rs = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
-hpke-rs-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
-hpke-rs-rust-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
+# feat: add p384 support
+# <https://github.com/cryspen/hpke-rs/pull/150>
+hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "eeeb9ed4204b608f257ec69166e67e25ebe8c8bd" }
+hpke-rs-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "eeeb9ed4204b608f257ec69166e67e25ebe8c8bd" }
+hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "eeeb9ed4204b608f257ec69166e67e25ebe8c8bd" }
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-openmls = { git = "https://github.com/openmls/openmls.git", branch = "konrad/hpqmls_dep_branch", features = [
+openmls = { git = "https://github.com/openmls/openmls.git", features = [
     "extensions-draft-08",
 ] }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls.git", branch = "konrad/hpqmls_dep_branch", features = [
+openmls_basic_credential = { git = "https://github.com/openmls/openmls.git", features = [
     "clonable",
 ] }
-openmls_traits = { git = "https://github.com/openmls/openmls.git", branch = "konrad/hpqmls_dep_branch", features = [
+openmls_traits = { git = "https://github.com/openmls/openmls.git", features = [
+    "extensions-draft-08",
+] }
+openmls_memory_storage = { git = "https://github.com/openmls/openmls.git", features = [
     "extensions-draft-08",
 ] }
 serde = "1.0.219"
@@ -23,4 +26,11 @@ thiserror = "2.0.12"
 tls_codec = "0.4.2"
 
 [dev-dependencies]
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git" }
+
+[patch."https://github.com/openmls/openmls.git"]
+openmls = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls_traits = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,13 @@ tls_codec = "0.4.2"
 openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git" }
 
 [patch."https://github.com/openmls/openmls.git"]
-openmls = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
-openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
-openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
-openmls_traits = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
-openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", branch = "konrad/hpqmls_dep_branch" }
+openmls = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+openmls_traits = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", branch = "dima/post-quantum-support" }
+
+[patch.crates-io]
+hpke-rs = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
+hpke-rs-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
+hpke-rs-rust-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", branch
 hpke-rs = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
 hpke-rs-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
 hpke-rs-rust-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
+
+[package.metadata.cargo-machete]
+ignored = [
+    "openmls_memory_storage", # include to enable the `extensions-draft-08` feature
+]

--- a/LICENSES/CC-BY-SA-4.0.txt
+++ b/LICENSES/CC-BY-SA-4.0.txt
@@ -1,0 +1,170 @@
+Creative Commons Attribution-ShareAlike 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described.
+
+Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	BY-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses, approved by Creative Commons as essentially the equivalent of this Public License.
+
+     d.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     e.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     f.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     g.	License Elements means the license attributes listed in the name of a Creative Commons Public License. The License Elements of this Public License are Attribution and ShareAlike.
+
+     h.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     i.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     j.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     k.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     l.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     m.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+
+               C. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6. No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+     b.	Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i.	identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii.	a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v.	a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+     b.	ShareAlike.In addition to the conditions in Section 3(a), if You Share Adapted Material You produce, the following conditions also apply.
+
+          1. The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+
+          2. You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
+
+          3. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b); and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# APQMLS - Amortized Post-Quantum MLS Combiner
+
+Implementation of the [MLS
+Combiner](https://www.ietf.org/archive/id/draft-ietf-mls-combiner-02.html)
+(draft-ietf-mls-combiner-02) -- an amortized post-quantum MLS combiner built on
+top of [OpenMLS](https://github.com/openmls/openmls).
+
+MLS is a secure group messaging protocol. The MLS Combiner runs a classical and
+a post-quantum MLS group in parallel and combines their key material to provide
+post-quantum security. The "amortized" aspect batches the post-quantum
+operations across multiple epochs, reducing per-message overhead.
+
+## License
+
+AGPL-3.0-or-later

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,5 +1,5 @@
 version = 1
-SPDX-PackageName = "HPQMLS"
+SPDX-PackageName = "APQMLS"
 SPDX-PackageSupplier = "Phoenix R&D GmbH <hello@phnx.im>"
 SPDX-PackageDownloadLocation = "https://github.com/phnx-im/infra"
 

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! This module defines types and traits for handling authentication in HPQMLS.
+//! This module defines types and traits for handling authentication in APQMLS.
 
 use openmls::prelude::{
     BasicCredential, CredentialWithKey, CryptoError, SignaturePublicKey, SignatureScheme,
@@ -13,16 +13,16 @@ use serde::{Deserialize, Serialize};
 use tap::Pipe;
 use tls_codec::{Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::HpqCiphersuite;
+use crate::ApqCiphersuite;
 
-/// The combined verifying key of a `[HpqSigner]`.
+/// The combined verifying key of a [`ApqSigner`].
 #[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserialize)]
-pub struct HpqVerifyingKey {
+pub struct ApqVerifyingKey {
     pub t_verifying_key: SignaturePublicKey,
     pub pq_verifying_key: SignaturePublicKey,
 }
 
-impl HpqVerifyingKey {
+impl ApqVerifyingKey {
     pub fn to_bytes(&self) -> Vec<u8> {
         // We unwrap here, because we know that public keys are not going to be
         // too long for the TLS codec to handle.
@@ -30,15 +30,15 @@ impl HpqVerifyingKey {
     }
 }
 
-/// A combined credential with key for use in HPQMLS.
+/// A combined credential with key for use in APQMLS.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct HpqCredentialWithKey {
+pub struct ApqCredentialWithKey {
     pub t_credential: CredentialWithKey,
     pub pq_credential: CredentialWithKey,
 }
 
-impl HpqCredentialWithKey {
-    pub fn new(identity: &[u8], keypair: &HpqSignatureKeyPair) -> Self {
+impl ApqCredentialWithKey {
+    pub fn new(identity: &[u8], keypair: &ApqSignatureKeyPair) -> Self {
         let t_credential = BasicCredential::new(identity.to_vec());
         let pq_credential = BasicCredential::new(identity.to_vec());
 
@@ -55,8 +55,8 @@ impl HpqCredentialWithKey {
     }
 }
 
-/// A trait for types that can sign messages in HPQMLS.
-pub trait HpqSigner {
+/// A trait for types that can sign messages in APQMLS.
+pub trait ApqSigner {
     fn t_signer(&self) -> &SignatureKeyPair;
     fn pq_signer(&self) -> &SignatureKeyPair;
 
@@ -67,23 +67,23 @@ pub trait HpqSigner {
         self.pq_signer().public()
     }
 
-    fn verifying_key(&self) -> HpqVerifyingKey {
-        HpqVerifyingKey {
+    fn verifying_key(&self) -> ApqVerifyingKey {
+        ApqVerifyingKey {
             t_verifying_key: self.t_verifying_key().into(),
             pq_verifying_key: self.pq_verifying_key().into(),
         }
     }
 }
 
-/// The signature scheme of a `[HpqSigner]`.
+/// The signature scheme of a [`ApqSigner`].
 #[derive(Debug, Clone, Copy)]
-pub struct HpqSignatureScheme {
+pub struct ApqSignatureScheme {
     pub t_signature_scheme: SignatureScheme,
     pub pq_signature_scheme: SignatureScheme,
 }
 
-impl From<HpqCiphersuite> for HpqSignatureScheme {
-    fn from(ciphersuite: HpqCiphersuite) -> Self {
+impl From<ApqCiphersuite> for ApqSignatureScheme {
+    fn from(ciphersuite: ApqCiphersuite) -> Self {
         Self {
             t_signature_scheme: ciphersuite.t_ciphersuite.signature_algorithm(),
             pq_signature_scheme: ciphersuite.pq_ciphersuite.signature_algorithm(),
@@ -91,15 +91,15 @@ impl From<HpqCiphersuite> for HpqSignatureScheme {
     }
 }
 
-/// A combined signature key pair for use in HPQMLS.
+/// A combined signature key pair for use in APQMLS.
 #[derive(Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, Serialize, Deserialize)]
-pub struct HpqSignatureKeyPair {
+pub struct ApqSignatureKeyPair {
     t_signer: SignatureKeyPair,
     pq_signer: SignatureKeyPair,
 }
 
-impl HpqSignatureKeyPair {
-    pub fn new(signature_scheme: HpqSignatureScheme) -> Result<Self, CryptoError> {
+impl ApqSignatureKeyPair {
+    pub fn new(signature_scheme: ApqSignatureScheme) -> Result<Self, CryptoError> {
         let t_signer = SignatureKeyPair::new(signature_scheme.t_signature_scheme)?;
         let pq_signer = SignatureKeyPair::new(signature_scheme.pq_signature_scheme)?;
         Self {
@@ -109,8 +109,8 @@ impl HpqSignatureKeyPair {
         .pipe(Ok)
     }
 
-    pub fn id(&self) -> HpqStorageId {
-        HpqStorageId {
+    pub fn id(&self) -> ApqStorageId {
+        ApqStorageId {
             t_signature_scheme: self.t_signer().signature_scheme(),
             t_verifying_key: self.t_verifying_key().to_vec(),
             pq_signature_scheme: self.pq_signer().signature_scheme(),
@@ -119,7 +119,7 @@ impl HpqSignatureKeyPair {
     }
 }
 
-impl HpqSigner for HpqSignatureKeyPair {
+impl ApqSigner for ApqSignatureKeyPair {
     fn t_signer(&self) -> &SignatureKeyPair {
         &self.t_signer
     }
@@ -129,9 +129,9 @@ impl HpqSigner for HpqSignatureKeyPair {
     }
 }
 
-/// The storage ID for a `[HpqSignatureKeyPair]`.
+/// The storage ID for a [`ApqSignatureKeyPair`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HpqStorageId {
+pub struct ApqStorageId {
     t_signature_scheme: SignatureScheme,
     t_verifying_key: Vec<u8>,
     pq_signature_scheme: SignatureScheme,
@@ -139,9 +139,9 @@ pub struct HpqStorageId {
 }
 
 // Implement key traits for the storage id
-impl storage::Key<CURRENT_VERSION> for HpqStorageId {}
-impl storage::traits::SignaturePublicKey<CURRENT_VERSION> for HpqStorageId {}
+impl storage::Key<CURRENT_VERSION> for ApqStorageId {}
+impl storage::traits::SignaturePublicKey<CURRENT_VERSION> for ApqStorageId {}
 
 // Implement entity trait for the signature key pair
-impl storage::Entity<CURRENT_VERSION> for HpqSignatureKeyPair {}
-impl storage::traits::SignatureKeyPair<CURRENT_VERSION> for HpqSignatureKeyPair {}
+impl storage::Entity<CURRENT_VERSION> for ApqSignatureKeyPair {}
+impl storage::traits::SignatureKeyPair<CURRENT_VERSION> for ApqSignatureKeyPair {}

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -171,14 +171,6 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
-    // /// Sets whether or not a [`openmls::messages::group_info::GroupInfo`] should be created when
-    // /// the commit is staged. Defaults to the value of the [`openmls::group::MlsGroup`]s
-    // /// [`openmls::group::MlsGroupJoinConfig`].
-    // pub fn create_group_info(mut self, create_group_info: bool) -> Self {
-    //     self.values.create_group_info = Some(create_group_info);
-    //     self
-    // }
-
     /// Sets whether or not the commit should force a self-update. Defaults to `false`.
     pub fn force_self_update(mut self, force_self_update: bool) -> Self {
         self.values.force_self_update = Some(force_self_update);

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -17,48 +17,48 @@ use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    HpqMlsGroup,
-    authentication::HpqSigner,
-    messages::{HpqGroupInfo, HpqKeyPackage, HpqMlsMessageOut, HpqWelcome},
-    psk::{HpqPskError, derive_and_store_psk},
+    ApqMlsGroup,
+    authentication::ApqSigner,
+    messages::{ApqGroupInfo, ApqKeyPackage, ApqMlsMessageOut, ApqWelcome},
+    psk::{ApqPskError, derive_and_store_psk},
 };
 
-/// Error while creating a commit in HPQMLS.
+/// Error while creating a commit in APQMLS.
 #[derive(Debug, Error)]
 pub enum CreateCommitError<StorageError> {
     #[error("Failed to build commit: {0}")]
     BuildCommit(#[from] OpenMlsCreateCommitError),
     #[error("Failed to stage commit: {0}")]
     StageCommit(#[from] CommitBuilderStageError<StorageError>),
-    #[error("Missing HPQInfo extension")]
-    MissingHpqInfo,
+    #[error("Missing APQInfo extension")]
+    MissingApqInfo,
     #[error("Malformed extension: {0}")]
     MalformedExtension(#[from] tls_codec::Error),
     #[error(transparent)]
-    Psk(#[from] HpqPskError<StorageError>),
+    Psk(#[from] ApqPskError<StorageError>),
     #[error(transparent)]
     Extension(#[from] InvalidExtensionError),
 }
 
-/// A message bundle resulting from a commit operation in HPQMLS.
-pub struct HpqCommitMessageBundle {
-    pub commit: HpqMlsMessageOut,
-    pub welcome: Option<HpqWelcome>,
-    pub group_info: Option<HpqGroupInfo>,
+/// A message bundle resulting from a commit operation in APQMLS.
+pub struct ApqCommitMessageBundle {
+    pub commit: ApqMlsMessageOut,
+    pub welcome: Option<ApqWelcome>,
+    pub group_info: Option<ApqGroupInfo>,
 }
 
-impl HpqCommitMessageBundle {
+impl ApqCommitMessageBundle {
     fn from_bundles(t_bundle: CommitMessageBundle, pq_bundle: CommitMessageBundle) -> Self {
         let (t_commit, t_welcome, t_group_info) = t_bundle.into_contents();
         let (pq_commit, pq_welcome, pq_group_info) = pq_bundle.into_contents();
 
-        let commit = HpqMlsMessageOut {
+        let commit = ApqMlsMessageOut {
             t_message: t_commit,
             pq_message: pq_commit,
         };
 
         let welcome = match (t_welcome, pq_welcome) {
-            (Some(t), Some(pq)) => Some(HpqWelcome {
+            (Some(t), Some(pq)) => Some(ApqWelcome {
                 t_welcome: t,
                 pq_welcome: pq,
             }),
@@ -71,7 +71,7 @@ impl HpqCommitMessageBundle {
 
         let group_info = t_group_info
             .zip(pq_group_info)
-            .map(|(t_group_info, pq_group_info)| HpqGroupInfo {
+            .map(|(t_group_info, pq_group_info)| ApqGroupInfo {
                 t_group_info,
                 pq_group_info,
             });
@@ -84,17 +84,17 @@ impl HpqCommitMessageBundle {
     }
 
     /// Consumes the bundle and returns the commit message.
-    pub fn into_message_out(self) -> HpqMlsMessageOut {
+    pub fn into_message_out(self) -> ApqMlsMessageOut {
         self.commit
     }
 
     /// Consumes the bundle and returns the welcome message, if any.
-    pub fn into_welcome(self) -> Option<HpqWelcome> {
+    pub fn into_welcome(self) -> Option<ApqWelcome> {
         self.welcome
     }
 
     /// Consumes the bundle and returns the group info, if any.
-    pub fn into_group_info(self) -> Option<HpqGroupInfo> {
+    pub fn into_group_info(self) -> Option<ApqGroupInfo> {
         self.group_info
     }
 }
@@ -107,7 +107,7 @@ struct ConfigValues {
     t_proposals: Vec<Proposal>,
     t_leaf_node_parameters: Option<LeafNodeParameters>,
     pq_leaf_node_parameters: Option<LeafNodeParameters>,
-    proposed_adds: Vec<HpqKeyPackage>,
+    proposed_adds: Vec<ApqKeyPackage>,
     proposed_removals: Vec<LeafNodeIndex>,
 }
 
@@ -148,16 +148,16 @@ impl ConfigValues {
     }
 }
 
-/// A builder for creating commits in an HPQMLS group. This builder can be used
+/// A builder for creating commits in an APQMLS group. This builder can be used
 /// to affect membership changes and issue full updates.
 pub struct CommitBuilder<'a> {
-    group: &'a mut HpqMlsGroup,
+    group: &'a mut ApqMlsGroup,
     values: ConfigValues,
 }
 
 impl<'a> CommitBuilder<'a> {
     /// returns a new [`CommitBuilder`] for the given [`openmls::group::MlsGroup`].
-    pub fn new(group: &'a mut HpqMlsGroup) -> Self {
+    pub fn new(group: &'a mut ApqMlsGroup) -> Self {
         Self {
             group,
             values: ConfigValues::default(),
@@ -219,7 +219,7 @@ impl<'a> CommitBuilder<'a> {
     /// Adds an Add proposal for each of the provided [`openmls::key_packages::KeyPackage`] tuples
     /// to the list of proposals to be committed. The first KeyPackage in each tuple must be the
     /// traditional one and the second the post-quantum one.
-    pub fn propose_adds(mut self, key_packages: impl IntoIterator<Item = HpqKeyPackage>) -> Self {
+    pub fn propose_adds(mut self, key_packages: impl IntoIterator<Item = ApqKeyPackage>) -> Self {
         self.values.proposed_adds.extend(key_packages);
         self
     }
@@ -238,26 +238,26 @@ impl<'a> CommitBuilder<'a> {
     /// - stage the commit
     ///
     /// TODO: Split this up to enable sans-io usage.
-    pub fn finalize<S: HpqSigner, Provider: OpenMlsProvider>(
+    pub fn finalize<S: ApqSigner, Provider: OpenMlsProvider>(
         self,
         provider: &Provider,
         signer: &S,
         t_f: impl FnMut(&QueuedProposal) -> bool,
         pq_f: impl FnMut(&QueuedProposal) -> bool,
-    ) -> Result<HpqCommitMessageBundle, CreateCommitError<Provider::StorageError>> {
-        let mut current_hpq_info = self
+    ) -> Result<ApqCommitMessageBundle, CreateCommitError<Provider::StorageError>> {
+        let mut current_apq_info = self
             .group
-            .hpq_info()
-            .ok_or_else(|| CreateCommitError::MissingHpqInfo)?;
+            .apq_info()
+            .ok_or_else(|| CreateCommitError::MissingApqInfo)?;
         let new_t_epoch = self.group.t_group.epoch().as_u64() + 1;
         let new_pq_epoch = self.group.pq_group.epoch().as_u64() + 1;
-        current_hpq_info.set_epoch(
+        current_apq_info.set_epoch(
             GroupEpoch::from(new_t_epoch),
             GroupEpoch::from(new_pq_epoch),
         );
 
         let mut current_extensions = self.group.t_group.extensions().clone();
-        current_extensions.add_or_replace(current_hpq_info.to_extension()?)?;
+        current_extensions.add_or_replace(current_apq_info.to_extension()?)?;
 
         // Create the PQ commit first s.t. we can export the PSK for the T group.
         let pq_result = self
@@ -290,6 +290,6 @@ impl<'a> CommitBuilder<'a> {
             .load_psks(provider.storage())?
             .build(provider.rand(), provider.crypto(), signer.t_signer(), t_f)?
             .stage_commit(provider)?;
-        Ok(HpqCommitMessageBundle::from_bundles(t_result, pq_result))
+        Ok(ApqCommitMessageBundle::from_bundles(t_result, pq_result))
     }
 }

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -7,7 +7,10 @@ use openmls::{
         CommitBuilder as MlsGroupCommitBuilder, CommitBuilderStageError, CommitMessageBundle,
         CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, QueuedProposal,
     },
-    prelude::{LeafNodeIndex, LeafNodeParameters, PreSharedKeyProposal, Proposal, ProposalType},
+    prelude::{
+        InvalidExtensionError, LeafNodeIndex, LeafNodeParameters, PreSharedKeyProposal, Proposal,
+        ProposalType,
+    },
     storage::OpenMlsProvider,
 };
 use tap::Pipe as _;
@@ -33,6 +36,8 @@ pub enum CreateCommitError<StorageError> {
     MalformedExtension(#[from] tls_codec::Error),
     #[error(transparent)]
     Psk(#[from] HpqPskError<StorageError>),
+    #[error(transparent)]
+    Extension(#[from] InvalidExtensionError),
 }
 
 /// A message bundle resulting from a commit operation in HPQMLS.
@@ -97,7 +102,7 @@ impl HpqCommitMessageBundle {
 #[derive(Debug, Clone, Default)]
 struct ConfigValues {
     consume_proposal_store: Option<bool>,
-    create_group_info: Option<bool>,
+    // create_group_info: Option<bool>,
     force_self_update: Option<bool>,
     t_proposals: Vec<Proposal>,
     t_leaf_node_parameters: Option<LeafNodeParameters>,
@@ -114,9 +119,9 @@ impl ConfigValues {
         if let Some(consume) = self.consume_proposal_store {
             builder = builder.consume_proposal_store(consume);
         }
-        if let Some(create) = self.create_group_info {
-            builder = builder.create_group_info(create);
-        }
+        // if let Some(create) = self.create_group_info {
+        //     builder = builder.create_group_info(create);
+        // }
         if let Some(force) = self.force_self_update {
             builder = builder.force_self_update(force);
         }
@@ -166,13 +171,13 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
-    /// Sets whether or not a [`openmls::messages::group_info::GroupInfo`] should be created when
-    /// the commit is staged. Defaults to the value of the [`openmls::group::MlsGroup`]s
-    /// [`openmls::group::MlsGroupJoinConfig`].
-    pub fn create_group_info(mut self, create_group_info: bool) -> Self {
-        self.values.create_group_info = Some(create_group_info);
-        self
-    }
+    // /// Sets whether or not a [`openmls::messages::group_info::GroupInfo`] should be created when
+    // /// the commit is staged. Defaults to the value of the [`openmls::group::MlsGroup`]s
+    // /// [`openmls::group::MlsGroupJoinConfig`].
+    // pub fn create_group_info(mut self, create_group_info: bool) -> Self {
+    //     self.values.create_group_info = Some(create_group_info);
+    //     self
+    // }
 
     /// Sets whether or not the commit should force a self-update. Defaults to `false`.
     pub fn force_self_update(mut self, force_self_update: bool) -> Self {
@@ -260,7 +265,7 @@ impl<'a> CommitBuilder<'a> {
         );
 
         let mut current_extensions = self.group.t_group.extensions().clone();
-        current_extensions.add_or_replace(current_hpq_info.to_extension()?);
+        current_extensions.add_or_replace(current_hpq_info.to_extension()?)?;
 
         // Create the PQ commit first s.t. we can export the PSK for the T group.
         let pq_result = self
@@ -268,7 +273,7 @@ impl<'a> CommitBuilder<'a> {
             .pq_group
             .commit_builder()
             .pipe(|b| self.values.apply::<false>(b))
-            .propose_group_context_extensions(current_extensions.clone())
+            .propose_group_context_extensions(current_extensions.clone())?
             .load_psks(provider.storage())?
             .build(provider.rand(), provider.crypto(), signer.pq_signer(), pq_f)?
             .stage_commit(provider)?;
@@ -289,7 +294,7 @@ impl<'a> CommitBuilder<'a> {
             .commit_builder()
             .pipe(|b| self.values.apply::<true>(b))
             .add_proposal(psk_proposal)
-            .propose_group_context_extensions(current_extensions)
+            .propose_group_context_extensions(current_extensions)?
             .load_psks(provider.storage())?
             .build(provider.rand(), provider.crypto(), signer.t_signer(), t_f)?
             .stage_commit(provider)?;

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -102,7 +102,6 @@ impl ApqCommitMessageBundle {
 #[derive(Debug, Clone, Default)]
 struct ConfigValues {
     consume_proposal_store: Option<bool>,
-    // create_group_info: Option<bool>,
     force_self_update: Option<bool>,
     t_proposals: Vec<Proposal>,
     t_leaf_node_parameters: Option<LeafNodeParameters>,
@@ -119,9 +118,6 @@ impl ConfigValues {
         if let Some(consume) = self.consume_proposal_store {
             builder = builder.consume_proposal_store(consume);
         }
-        // if let Some(create) = self.create_group_info {
-        //     builder = builder.create_group_info(create);
-        // }
         if let Some(force) = self.force_self_update {
             builder = builder.force_self_update(force);
         }

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,17 +5,17 @@
 use openmls::{group::ExportGroupInfoError, prelude::OpenMlsCrypto};
 
 use crate::{
-    HpqMlsGroup,
-    authentication::HpqSigner,
-    messages::{HpqMlsMessageOut, HpqRatchetTree},
+    ApqMlsGroup,
+    authentication::ApqSigner,
+    messages::{ApqMlsMessageOut, ApqRatchetTree},
 };
 
-impl HpqMlsGroup {
+impl ApqMlsGroup {
     /// Export the ratchet tree of the group.
-    pub fn export_ratchet_tree(&self) -> HpqRatchetTree {
+    pub fn export_ratchet_tree(&self) -> ApqRatchetTree {
         let t_ratchet_tree = self.t_group.export_ratchet_tree();
         let pq_ratchet_tree = self.pq_group.export_ratchet_tree();
-        HpqRatchetTree {
+        ApqRatchetTree {
             t_ratchet_tree,
             pq_ratchet_tree,
         }
@@ -25,16 +25,16 @@ impl HpqMlsGroup {
     pub fn export_group_info(
         &self,
         crypto: &impl OpenMlsCrypto,
-        signer: &impl HpqSigner,
+        signer: &impl ApqSigner,
         with_ratchet_tree: bool,
-    ) -> Result<HpqMlsMessageOut, ExportGroupInfoError> {
+    ) -> Result<ApqMlsMessageOut, ExportGroupInfoError> {
         let t_group_info =
             self.t_group
                 .export_group_info(crypto, signer.t_signer(), with_ratchet_tree)?;
         let pq_group_info =
             self.pq_group
                 .export_group_info(crypto, signer.pq_signer(), with_ratchet_tree)?;
-        let group_info = HpqMlsMessageOut {
+        let group_info = ApqMlsMessageOut {
             t_message: t_group_info,
             pq_message: pq_group_info,
         };

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -9,12 +9,12 @@ use openmls::{
 use tap::Pipe;
 use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::{HpqCiphersuite, HpqGroupId, HpqMlsGroup};
+use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup};
 
-pub const HPQMLS_EXTENSION_ID: u16 = 0xFF01;
-pub const HPQMLS_EXTENSION_TYPE: ExtensionType = ExtensionType::Unknown(HPQMLS_EXTENSION_ID);
+pub const APQMLS_EXTENSION_ID: u16 = 0xFF01;
+pub const APQMLS_EXTENSION_TYPE: ExtensionType = ExtensionType::Unknown(APQMLS_EXTENSION_ID);
 
-/// The mode of an [`HpqMlsGroup`], which determines whether only confidentiality or both
+/// The mode of an [`ApqMlsGroup`], which determines whether only confidentiality or both
 /// confidentiality and authentication is PQ secure.
 #[derive(Default, Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -35,18 +35,18 @@ impl From<PqtMode> for bool {
 
 impl PqtMode {
     /// Returns the default ciphersuite for the given mode.
-    pub fn default_ciphersuite(&self) -> HpqCiphersuite {
+    pub fn default_ciphersuite(&self) -> ApqCiphersuite {
         match self {
-            PqtMode::ConfOnly => HpqCiphersuite::default_pq_conf(),
-            PqtMode::ConfAndAuth => HpqCiphersuite::default_pq_conf_and_auth(),
+            PqtMode::ConfOnly => ApqCiphersuite::default_pq_conf(),
+            PqtMode::ConfAndAuth => ApqCiphersuite::default_pq_conf_and_auth(),
         }
     }
 }
 
-/// The HPQMLS extension, which is used to store HPQMLS-specific information
-/// in the extensions of an `[MlsGroup]`.
+/// The APQMLS extension, which is used to store APQMLS-specific information
+/// in the extensions of an [`openmls::group::MlsGroup`].
 #[derive(Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, PartialEq, Eq)]
-pub struct HpqMlsInfo {
+pub struct ApqMlsInfo {
     pub t_session_group_id: GroupId,
     pub pq_session_group_id: GroupId,
     pub mode: PqtMode,
@@ -56,11 +56,11 @@ pub struct HpqMlsInfo {
     pub pq_epoch: GroupEpoch,
 }
 
-impl HpqMlsInfo {
+impl ApqMlsInfo {
     pub(super) fn to_extension(&self) -> Result<Extension, tls_codec::Error> {
         self.tls_serialize_detached()?
             .pipe(UnknownExtension)
-            .pipe(|extension| Extension::Unknown(HPQMLS_EXTENSION_ID, extension))
+            .pipe(|extension| Extension::Unknown(APQMLS_EXTENSION_ID, extension))
             .pipe(Ok)
     }
 
@@ -72,18 +72,18 @@ impl HpqMlsInfo {
     pub fn from_extensions(
         extensions: &Extensions<GroupContext>,
     ) -> Result<Option<Self>, tls_codec::Error> {
-        if let Some(extension) = extensions.unknown(HPQMLS_EXTENSION_ID) {
+        if let Some(extension) = extensions.unknown(APQMLS_EXTENSION_ID) {
             extension
                 .0
-                .pipe_as_ref::<'_, [u8], _>(HpqMlsInfo::tls_deserialize_exact)
+                .pipe_as_ref::<'_, [u8], _>(ApqMlsInfo::tls_deserialize_exact)
                 .map(Some)
         } else {
             Ok(None)
         }
     }
 
-    pub fn group_id(&self) -> HpqGroupId {
-        HpqGroupId {
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
             t_group_id: self.t_session_group_id.clone(),
             pq_group_id: self.pq_session_group_id.clone(),
         }
@@ -94,8 +94,8 @@ pub(super) fn ensure_extension_support(
     capabilities: Capabilities,
 ) -> Result<Capabilities, tls_codec::Error> {
     let mut extensions = capabilities.extensions().to_vec();
-    if !extensions.contains(&HPQMLS_EXTENSION_TYPE) {
-        extensions.push(HPQMLS_EXTENSION_TYPE);
+    if !extensions.contains(&APQMLS_EXTENSION_TYPE) {
+        extensions.push(APQMLS_EXTENSION_TYPE);
     }
     if !extensions.contains(&ExtensionType::RequiredCapabilities) {
         extensions.push(ExtensionType::RequiredCapabilities);
@@ -115,9 +115,9 @@ pub(super) fn ensure_extension_support(
     .pipe(Ok)
 }
 
-impl HpqMlsGroup {
-    /// Get the HPQMLS extension from the group, if it exists.
-    pub fn hpq_info(&self) -> Option<HpqMlsInfo> {
-        HpqMlsInfo::from_extensions(self.t_group.extensions()).ok()?
+impl ApqMlsGroup {
+    /// Get the APQMLS extension from the group, if it exists.
+    pub fn apq_info(&self) -> Option<ApqMlsInfo> {
+        ApqMlsInfo::from_extensions(self.t_group.extensions()).ok()?
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -60,7 +60,7 @@ impl HpqMlsInfo {
     pub(super) fn to_extension(&self) -> Result<Extension, tls_codec::Error> {
         self.tls_serialize_detached()?
             .pipe(UnknownExtension)
-            .pipe(|ue| Extension::Unknown(HPQMLS_EXTENSION_ID, ue))
+            .pipe(|extension| Extension::Unknown(HPQMLS_EXTENSION_ID, extension))
             .pipe(Ok)
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
-    group::{GroupEpoch, GroupId},
+    group::{GroupContext, GroupEpoch, GroupId},
     prelude::{Capabilities, Ciphersuite, Extension, ExtensionType, Extensions, UnknownExtension},
 };
 use tap::Pipe;
@@ -69,7 +69,9 @@ impl HpqMlsInfo {
         self.pq_epoch = pq_epoch;
     }
 
-    pub fn from_extensions(extensions: &Extensions) -> Result<Option<Self>, tls_codec::Error> {
+    pub fn from_extensions(
+        extensions: &Extensions<GroupContext>,
+    ) -> Result<Option<Self>, tls_codec::Error> {
         if let Some(extension) = extensions.unknown(HPQMLS_EXTENSION_ID) {
             extension
                 .0

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -4,12 +4,12 @@
 
 use openmls::{
     group::{
-        GroupEpoch, GroupId, MlsGroupBuilder, NewGroupError as OpenMlsNewGroupError,
+        GroupContext, GroupEpoch, GroupId, MlsGroupBuilder, NewGroupError as OpenMlsNewGroupError,
         WireFormatPolicy,
     },
     prelude::{
-        Capabilities, Extension, ExtensionType, Extensions, InvalidExtensionError, Lifetime,
-        RequiredCapabilitiesExtension, SenderRatchetConfiguration,
+        Capabilities, Extension, ExtensionType, Extensions, InvalidExtensionError, LeafNode,
+        Lifetime, RequiredCapabilitiesExtension, SenderRatchetConfiguration,
     },
     storage::OpenMlsProvider,
     treesync::errors::LeafNodeValidationError,
@@ -49,8 +49,8 @@ pub struct GroupBuilder {
     group_ids: Option<HpqGroupId>,
     mode: PqtMode,
     capabilities: Capabilities,
-    t_extensions: Extensions,
-    pq_extensions: Extensions,
+    t_extensions: Extensions<GroupContext>,
+    pq_extensions: Extensions<GroupContext>,
 }
 
 impl GroupBuilder {
@@ -106,8 +106,8 @@ impl GroupBuilder {
         )
         .pipe(Extension::RequiredCapabilities);
 
-        self.t_extensions.add_or_replace(rc_extension.clone());
-        self.pq_extensions.add_or_replace(rc_extension);
+        self.t_extensions.add_or_replace(rc_extension.clone())?;
+        self.pq_extensions.add_or_replace(rc_extension)?;
 
         let hpq_mls_extension = HpqMlsInfo {
             t_session_group_id: hpq_group_id.t_group_id.clone(),
@@ -120,13 +120,14 @@ impl GroupBuilder {
         }
         .to_extension()?;
 
-        self.t_extensions.add_or_replace(hpq_mls_extension.clone());
-        self.pq_extensions.add_or_replace(hpq_mls_extension);
+        self.t_extensions
+            .add_or_replace(hpq_mls_extension.clone())?;
+        self.pq_extensions.add_or_replace(hpq_mls_extension)?;
 
         let t_group = self
             .t_group_builder
             .ciphersuite(ciphersuite.t_ciphersuite)
-            .with_group_context_extensions(self.t_extensions)?
+            .with_group_context_extensions(self.t_extensions)
             .with_group_id(hpq_group_id.t_group_id.clone())
             .with_capabilities(capabilities.clone())
             .build(
@@ -137,7 +138,7 @@ impl GroupBuilder {
         let pq_group = self
             .pq_group_builder
             .ciphersuite(ciphersuite.pq_ciphersuite)
-            .with_group_context_extensions(self.pq_extensions)?
+            .with_group_context_extensions(self.pq_extensions)
             .with_group_id(hpq_group_id.pq_group_id.clone())
             .with_capabilities(capabilities)
             .build(
@@ -231,8 +232,8 @@ impl GroupBuilder {
     /// Sets the initial group context extensions
     pub fn with_group_context_extensions(
         mut self,
-        t_extensions: Extensions,
-        pq_extensions: Extensions,
+        t_extensions: Extensions<GroupContext>,
+        pq_extensions: Extensions<GroupContext>,
     ) -> Result<Self, InvalidExtensionError> {
         self.t_extensions = t_extensions;
         self.pq_extensions = pq_extensions;
@@ -243,8 +244,8 @@ impl GroupBuilder {
     /// Sets the initial leaf node extensions
     pub fn with_leaf_node_extensions(
         mut self,
-        t_extensions: Extensions,
-        pq_extensions: Extensions,
+        t_extensions: Extensions<LeafNode>,
+        pq_extensions: Extensions<LeafNode>,
     ) -> Result<Self, LeafNodeValidationError> {
         self.t_group_builder = self
             .t_group_builder

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -18,8 +18,8 @@ use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    ApqGroupId, ApqMlsGroup, ApqCiphersuite,
-    authentication::{ApqSigner, ApqCredentialWithKey},
+    ApqCiphersuite, ApqGroupId, ApqMlsGroup,
+    authentication::{ApqCredentialWithKey, ApqSigner},
     extension::{APQMLS_EXTENSION_TYPE, ApqMlsInfo, PqtMode, ensure_extension_support},
     key_package::ensure_ciphersuite_support,
 };

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -124,6 +124,8 @@ impl GroupBuilder {
             .add_or_replace(hpq_mls_extension.clone())?;
         self.pq_extensions.add_or_replace(hpq_mls_extension)?;
 
+        dbg!(&ciphersuite.pq_ciphersuite);
+
         let t_group = self
             .t_group_builder
             .ciphersuite(ciphersuite.t_ciphersuite)

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -124,8 +124,6 @@ impl GroupBuilder {
             .add_or_replace(hpq_mls_extension.clone())?;
         self.pq_extensions.add_or_replace(hpq_mls_extension)?;
 
-        dbg!(&ciphersuite.pq_ciphersuite);
-
         let t_group = self
             .t_group_builder
             .ciphersuite(ciphersuite.t_ciphersuite)

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -18,18 +18,18 @@ use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    HpqCiphersuite, HpqGroupId, HpqMlsGroup,
-    authentication::{HpqCredentialWithKey, HpqSigner},
-    extension::{HPQMLS_EXTENSION_TYPE, HpqMlsInfo, PqtMode, ensure_extension_support},
+    ApqGroupId, ApqMlsGroup, ApqCiphersuite,
+    authentication::{ApqSigner, ApqCredentialWithKey},
+    extension::{APQMLS_EXTENSION_TYPE, ApqMlsInfo, PqtMode, ensure_extension_support},
     key_package::ensure_ciphersuite_support,
 };
 
-/// Errors that can occur when creating a new [`HpqMlsGroup`].
+/// Errors that can occur when creating a new [`ApqMlsGroup`].
 #[derive(Error, Debug)]
 pub enum NewGroupError<StorageError> {
     #[error(transparent)]
     NewGroup(#[from] OpenMlsNewGroupError<StorageError>),
-    #[error("Error serializing HPQInfo extension: {0}")]
+    #[error("Error serializing APQInfo extension: {0}")]
     InvalidExtension(#[from] tls_codec::Error),
 }
 
@@ -39,14 +39,14 @@ impl<StorageError> From<InvalidExtensionError> for NewGroupError<StorageError> {
     }
 }
 
-/// A builder for creating a new [`HpqMlsGroup`].
+/// A builder for creating a new [`ApqMlsGroup`].
 #[derive(Debug, Default)]
 pub struct GroupBuilder {
     t_group_builder: MlsGroupBuilder,
     pq_group_builder: MlsGroupBuilder,
     // We keep track of the values below so we can do some post-processing
     // later.
-    group_ids: Option<HpqGroupId>,
+    group_ids: Option<ApqGroupId>,
     mode: PqtMode,
     capabilities: Capabilities,
     t_extensions: Extensions<GroupContext>,
@@ -58,17 +58,17 @@ impl GroupBuilder {
         Self::default()
     }
 
-    /// Sets the [`PqtMode`] mode of the [`HpqMlsGroup`].
+    /// Sets the [`PqtMode`] mode of the [`ApqMlsGroup`].
     pub fn set_mode(mut self, mode: PqtMode) -> Self {
         self.mode = mode;
         self
     }
 
-    /// Sets the group ID of the [`HpqMlsGroup`].
+    /// Sets the group ID of the [`ApqMlsGroup`].
     pub fn with_group_ids(mut self, t_group_id: GroupId, pq_group_id: GroupId) -> Self {
         self.t_group_builder = self.t_group_builder.with_group_id(t_group_id.clone());
         self.pq_group_builder = self.pq_group_builder.with_group_id(pq_group_id.clone());
-        self.group_ids = Some(HpqGroupId {
+        self.group_ids = Some(ApqGroupId {
             t_group_id,
             pq_group_id,
         });
@@ -79,12 +79,12 @@ impl GroupBuilder {
     pub fn build<Provider: OpenMlsProvider>(
         mut self,
         provider: &Provider,
-        signer: &impl HpqSigner,
-        credential_with_key: HpqCredentialWithKey,
-    ) -> Result<HpqMlsGroup, NewGroupError<Provider::StorageError>> {
+        signer: &impl ApqSigner,
+        credential_with_key: ApqCredentialWithKey,
+    ) -> Result<ApqMlsGroup, NewGroupError<Provider::StorageError>> {
         let ciphersuite = match self.mode {
-            PqtMode::ConfOnly => HpqCiphersuite::default_pq_conf(),
-            PqtMode::ConfAndAuth => HpqCiphersuite::default_pq_conf_and_auth(),
+            PqtMode::ConfOnly => ApqCiphersuite::default_pq_conf(),
+            PqtMode::ConfAndAuth => ApqCiphersuite::default_pq_conf_and_auth(),
         };
 
         // Add extension to capabilities.
@@ -94,13 +94,13 @@ impl GroupBuilder {
             .pipe(|c| ensure_ciphersuite_support(c, ciphersuite))?;
 
         // Add extension to extensions
-        let hpq_group_id = self
+        let apq_group_id = self
             .group_ids
-            .unwrap_or_else(|| HpqGroupId::random(provider.rand()));
+            .unwrap_or_else(|| ApqGroupId::random(provider.rand()));
 
         // Add required capabilities extension
         let rc_extension = RequiredCapabilitiesExtension::new(
-            &[HPQMLS_EXTENSION_TYPE, ExtensionType::RequiredCapabilities],
+            &[APQMLS_EXTENSION_TYPE, ExtensionType::RequiredCapabilities],
             &[],
             &[],
         )
@@ -109,9 +109,9 @@ impl GroupBuilder {
         self.t_extensions.add_or_replace(rc_extension.clone())?;
         self.pq_extensions.add_or_replace(rc_extension)?;
 
-        let hpq_mls_extension = HpqMlsInfo {
-            t_session_group_id: hpq_group_id.t_group_id.clone(),
-            pq_session_group_id: hpq_group_id.pq_group_id.clone(),
+        let apq_mls_extension = ApqMlsInfo {
+            t_session_group_id: apq_group_id.t_group_id.clone(),
+            pq_session_group_id: apq_group_id.pq_group_id.clone(),
             mode: self.mode,
             t_cipher_suite: ciphersuite.t_ciphersuite,
             pq_cipher_suite: ciphersuite.pq_ciphersuite,
@@ -121,14 +121,14 @@ impl GroupBuilder {
         .to_extension()?;
 
         self.t_extensions
-            .add_or_replace(hpq_mls_extension.clone())?;
-        self.pq_extensions.add_or_replace(hpq_mls_extension)?;
+            .add_or_replace(apq_mls_extension.clone())?;
+        self.pq_extensions.add_or_replace(apq_mls_extension)?;
 
         let t_group = self
             .t_group_builder
             .ciphersuite(ciphersuite.t_ciphersuite)
             .with_group_context_extensions(self.t_extensions)
-            .with_group_id(hpq_group_id.t_group_id.clone())
+            .with_group_id(apq_group_id.t_group_id.clone())
             .with_capabilities(capabilities.clone())
             .build(
                 provider,
@@ -139,7 +139,7 @@ impl GroupBuilder {
             .pq_group_builder
             .ciphersuite(ciphersuite.pq_ciphersuite)
             .with_group_context_extensions(self.pq_extensions)
-            .with_group_id(hpq_group_id.pq_group_id.clone())
+            .with_group_id(apq_group_id.pq_group_id.clone())
             .with_capabilities(capabilities)
             .build(
                 provider,
@@ -147,12 +147,12 @@ impl GroupBuilder {
                 credential_with_key.pq_credential,
             )?;
 
-        Ok(HpqMlsGroup { pq_group, t_group })
+        Ok(ApqMlsGroup { pq_group, t_group })
     }
 
     // Builder options
 
-    /// Sets the `wire_format` property of the HpqMlsGroup.
+    /// Sets the `wire_format` property of the ApqMlsGroup.
     pub fn with_wire_format_policy(mut self, wire_format_policy: WireFormatPolicy) -> Self {
         self.t_group_builder = self
             .t_group_builder
@@ -163,7 +163,7 @@ impl GroupBuilder {
         self
     }
 
-    /// Sets the `padding_size` property of the HpqMlsGroup.
+    /// Sets the `padding_size` property of the ApqMlsGroup.
     pub fn padding_size(mut self, padding_size: usize) -> Self {
         self.t_group_builder = self.t_group_builder.padding_size(padding_size);
         self.pq_group_builder = self.pq_group_builder.padding_size(padding_size);
@@ -186,7 +186,7 @@ impl GroupBuilder {
         self
     }
 
-    /// Sets the `number_of_resumption_psks` property of the HpqMlsGroup.
+    /// Sets the `number_of_resumption_psks` property of the ApqMlsGroup.
     pub fn number_of_resumption_psks(mut self, number_of_resumption_psks: usize) -> Self {
         self.t_group_builder = self
             .t_group_builder

--- a/src/key_package.rs
+++ b/src/key_package.rs
@@ -6,8 +6,8 @@ use std::collections::HashSet;
 
 use openmls::{
     prelude::{
-        Capabilities, Ciphersuite, Extensions, KeyPackageBuilder, KeyPackageBundle,
-        KeyPackageNewError as OpenMlsKeyPackageNewError, KeyPackageVerifyError, Lifetime,
+        Capabilities, Ciphersuite, Extensions, KeyPackage, KeyPackageBuilder, KeyPackageBundle,
+        KeyPackageNewError as OpenMlsKeyPackageNewError, KeyPackageVerifyError, LeafNode, Lifetime,
         OpenMlsCrypto, ProtocolVersion,
     },
     storage::OpenMlsProvider,
@@ -80,7 +80,7 @@ impl HpqKeyPackageBuilder {
     }
 
     /// Set the key package extensions.
-    pub fn key_package_extensions(mut self, extensions: Extensions) -> Self {
+    pub fn key_package_extensions(mut self, extensions: Extensions<KeyPackage>) -> Self {
         self.t_kp_builder = self.t_kp_builder.key_package_extensions(extensions.clone());
         self.pq_kp_builder = self.pq_kp_builder.key_package_extensions(extensions);
         self
@@ -102,7 +102,7 @@ impl HpqKeyPackageBuilder {
     }
 
     /// Set the leaf node extensions.
-    pub fn leaf_node_extensions(mut self, extensions: Extensions) -> Self {
+    pub fn leaf_node_extensions(mut self, extensions: Extensions<LeafNode>) -> Self {
         self.t_kp_builder = self.t_kp_builder.leaf_node_extensions(extensions.clone());
         self.pq_kp_builder = self.pq_kp_builder.leaf_node_extensions(extensions);
         self

--- a/src/key_package.rs
+++ b/src/key_package.rs
@@ -17,13 +17,13 @@ use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    HpqCiphersuite,
-    authentication::{HpqCredentialWithKey, HpqSigner},
+    ApqCiphersuite,
+    authentication::{ApqSigner, ApqCredentialWithKey},
     extension::ensure_extension_support,
-    messages::{HpqKeyPackage, HpqKeyPackageIn},
+    messages::{ApqKeyPackage, ApqKeyPackageIn},
 };
 
-/// Errors that can occur when creating a new [`HpqKeyPackage`].
+/// Errors that can occur when creating a new [`ApqKeyPackage`].
 #[derive(Error, Debug)]
 pub enum KeyPackageNewError {
     #[error(transparent)]
@@ -32,37 +32,37 @@ pub enum KeyPackageNewError {
     UnsupportedCiphersuite(#[from] tls_codec::Error),
 }
 
-/// A builder for creating a new [`HpqKeyPackage`].
-pub struct HpqKeyPackageBuilder {
+/// A builder for creating a new [`ApqKeyPackage`].
+pub struct ApqKeyPackageBuilder {
     capabilities: Capabilities,
     t_kp_builder: KeyPackageBuilder,
     pq_kp_builder: KeyPackageBuilder,
 }
 
-/// A bundle consisting of an [`HpqKeyPackage`] and its corresponding
+/// A bundle consisting of an [`ApqKeyPackage`] and its corresponding
 /// private keys.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HpqKeyPackageBundle {
+pub struct ApqKeyPackageBundle {
     t_kp_bundle: KeyPackageBundle,
     pq_kp_bundle: KeyPackageBundle,
 }
 
-impl HpqKeyPackageBundle {
-    pub fn into_key_package(self) -> HpqKeyPackage {
-        HpqKeyPackage {
+impl ApqKeyPackageBundle {
+    pub fn into_key_package(self) -> ApqKeyPackage {
+        ApqKeyPackage {
             t_key_package: self.t_kp_bundle.key_package().clone(),
             pq_key_package: self.pq_kp_bundle.key_package().clone(),
         }
     }
 }
 
-impl Default for HpqKeyPackageBuilder {
+impl Default for ApqKeyPackageBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl HpqKeyPackageBuilder {
+impl ApqKeyPackageBuilder {
     /// Create a key package builder.
     pub fn new() -> Self {
         Self {
@@ -112,10 +112,10 @@ impl HpqKeyPackageBuilder {
     pub fn build(
         mut self,
         provider: &impl OpenMlsProvider,
-        ciphersuite: HpqCiphersuite,
-        signer: &impl HpqSigner,
-        credential_with_key: HpqCredentialWithKey,
-    ) -> Result<HpqKeyPackageBundle, KeyPackageNewError> {
+        ciphersuite: ApqCiphersuite,
+        signer: &impl ApqSigner,
+        credential_with_key: ApqCredentialWithKey,
+    ) -> Result<ApqKeyPackageBundle, KeyPackageNewError> {
         let capabilities = self
             .capabilities
             .pipe(ensure_extension_support)?
@@ -137,28 +137,28 @@ impl HpqKeyPackageBuilder {
             signer.pq_signer(),
             credential_with_key.pq_credential,
         )?;
-        Ok(HpqKeyPackageBundle {
+        Ok(ApqKeyPackageBundle {
             t_kp_bundle,
             pq_kp_bundle,
         })
     }
 }
 
-impl HpqKeyPackage {
-    pub fn builder() -> HpqKeyPackageBuilder {
-        HpqKeyPackageBuilder::new()
+impl ApqKeyPackage {
+    pub fn builder() -> ApqKeyPackageBuilder {
+        ApqKeyPackageBuilder::new()
     }
 }
 
-impl HpqKeyPackageIn {
+impl ApqKeyPackageIn {
     pub fn validate(
         self,
         crypto: &impl OpenMlsCrypto,
-    ) -> Result<HpqKeyPackage, KeyPackageVerifyError> {
+    ) -> Result<ApqKeyPackage, KeyPackageVerifyError> {
         let protocol_version = ProtocolVersion::default();
         let t_key_package = self.t_key_package.validate(crypto, protocol_version)?;
         let pq_key_package = self.pq_key_package.validate(crypto, protocol_version)?;
-        Ok(HpqKeyPackage {
+        Ok(ApqKeyPackage {
             t_key_package,
             pq_key_package,
         })
@@ -167,7 +167,7 @@ impl HpqKeyPackageIn {
 
 pub(super) fn ensure_ciphersuite_support(
     capabilities: Capabilities,
-    ciphersuite: HpqCiphersuite,
+    ciphersuite: ApqCiphersuite,
 ) -> Result<Capabilities, tls_codec::Error> {
     let mut ciphersuites: HashSet<Ciphersuite> = capabilities
         .ciphersuites()

--- a/src/key_package.rs
+++ b/src/key_package.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 
 use crate::{
     ApqCiphersuite,
-    authentication::{ApqSigner, ApqCredentialWithKey},
+    authentication::{ApqCredentialWithKey, ApqSigner},
     extension::ensure_extension_support,
     messages::{ApqKeyPackage, ApqKeyPackageIn},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,18 +2,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! # HPQMLS
+//! # APQMLS
 //!
 //! This crate provides an implementation of
-//! [HPQMLS](https://datatracker.ietf.org/doc/draft-ietf-mls-combiner/), a
+//! [APQMLS](https://datatracker.ietf.org/doc/draft-ietf-mls-combiner/), a
 //! mechanism that combines two MLS groups, one with a traditional ciphersuite
-//! and one with a post-quantum ciphersuite. An [HPQMLS group](HpqMlsGroup)
+//! and one with a post-quantum ciphersuite. An [APQMLS group](ApqMlsGroup)
 //! provides PQ security and "full" updates, as well as updates to group
 //! membership provide PQ FS and PCS. In addition, the traditional group can be
 //! used independently, except for membership updates, e.g. Independent use of
 //! the traditional group, for example, allows for cheaper non-PQ PCS updates.
 //!
-//! A HPQMLS group can be run in one of two modes: "confidentiality and
+//! A APQMLS group can be run in one of two modes: "confidentiality and
 //! authentication" mode, where the post-quantum ciphersuite provides both both
 //! PQ confidentiality and PQ authentication, and "confidentiality-only" mode,
 //! where the post-quantum ciphersuite only provides PQ confidentiality with
@@ -27,7 +27,7 @@ use openmls::{
 use serde::{Deserialize, Serialize};
 use tls_codec::{TlsSerialize, TlsSize};
 
-use crate::{authentication::HpqVerifyingKey, group_builder::GroupBuilder};
+use crate::{authentication::ApqVerifyingKey, group_builder::GroupBuilder};
 
 pub mod authentication;
 pub mod commit_builder;
@@ -41,14 +41,14 @@ pub mod processing;
 mod psk;
 pub mod welcome;
 
-/// The combined ciphersuite of a `[HpqMlsGroup]`.
+/// The combined ciphersuite of a [`ApqMlsGroup`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
-pub struct HpqCiphersuite {
+pub struct ApqCiphersuite {
     t_ciphersuite: Ciphersuite,
     pq_ciphersuite: Ciphersuite,
 }
 
-impl HpqCiphersuite {
+impl ApqCiphersuite {
     pub const fn default_pq_conf_and_auth() -> Self {
         Self {
             t_ciphersuite: Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
@@ -64,14 +64,14 @@ impl HpqCiphersuite {
     }
 }
 
-/// The group ID of a `[HpqMlsGroup]`.
+/// The group ID of a [`ApqMlsGroup`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize, TlsSerialize)]
-pub struct HpqGroupId {
+pub struct ApqGroupId {
     t_group_id: GroupId,
     pq_group_id: GroupId,
 }
 
-impl HpqGroupId {
+impl ApqGroupId {
     pub fn random(rng: &impl OpenMlsRand) -> Self {
         Self {
             t_group_id: GroupId::random(rng),
@@ -80,42 +80,42 @@ impl HpqGroupId {
     }
 }
 
-/// An HPQMLS group, consisting of a traditional MLS group and a post-quantum MLS
+/// An APQMLS group, consisting of a traditional MLS group and a post-quantum MLS
 /// group. The two traditional group can be used independently, except for
 /// membership updates.
 #[derive(Debug)]
-pub struct HpqMlsGroup {
+pub struct ApqMlsGroup {
     pq_group: MlsGroup,
     pub t_group: MlsGroup,
 }
 
-impl HpqMlsGroup {
+impl ApqMlsGroup {
     /// Returns a reference to the post-quantum group.
     pub fn pq_group(&self) -> &MlsGroup {
         &self.pq_group
     }
 
-    /// Build a new HPQMLS group.
+    /// Build a new APQMLS group.
     pub fn builder() -> GroupBuilder {
         GroupBuilder::new()
     }
 
-    /// Creates a commit builder for the HPQMLS group. This builder can be used
+    /// Creates a commit builder for the APQMLS group. This builder can be used
     /// to affect membership changes and issue full updates.
     pub fn commit_builder(&mut self) -> commit_builder::CommitBuilder<'_> {
         commit_builder::CommitBuilder::new(self)
     }
 
-    /// Returns the group ID of the HPQMLS group.
-    pub fn group_id(&self) -> HpqGroupId {
-        HpqGroupId {
+    /// Returns the group ID of the APQMLS group.
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
             t_group_id: self.t_group.group_id().clone(),
             pq_group_id: self.pq_group.group_id().clone(),
         }
     }
 
-    pub fn ciphersuite(&self) -> HpqCiphersuite {
-        HpqCiphersuite {
+    pub fn ciphersuite(&self) -> ApqCiphersuite {
+        ApqCiphersuite {
             t_ciphersuite: self.t_group.ciphersuite(),
             pq_ciphersuite: self.pq_group.ciphersuite(),
         }
@@ -131,20 +131,20 @@ impl HpqMlsGroup {
         self.pq_group.epoch()
     }
 
-    /// Returns the `[HpqVerifyingKey]` of the member at the given index.
-    pub fn verifying_key_at(&self, index: LeafNodeIndex) -> Option<HpqVerifyingKey> {
+    /// Returns the [`ApqVerifyingKey`] of the member at the given index.
+    pub fn verifying_key_at(&self, index: LeafNodeIndex) -> Option<ApqVerifyingKey> {
         let t_member = self.t_group.member_at(index)?;
         let pq_member = self.pq_group.member_at(index)?;
-        Some(HpqVerifyingKey {
+        Some(ApqVerifyingKey {
             t_verifying_key: t_member.signature_key.into(),
             pq_verifying_key: pq_member.signature_key.into(),
         })
     }
 
-    /// Load an HPQMLS group from storage.
+    /// Load an APQMLS group from storage.
     pub fn load<Storage: StorageProvider>(
         provider: &Storage,
-        group_id: &HpqGroupId,
+        group_id: &ApqGroupId,
     ) -> Result<Option<Self>, Storage::Error> {
         let t_group = MlsGroup::load(provider, &group_id.t_group_id)?;
         let pq_group = MlsGroup::load(provider, &group_id.pq_group_id)?;
@@ -154,7 +154,7 @@ impl HpqMlsGroup {
             .map(|(t_group, pq_group)| Self { pq_group, t_group }))
     }
 
-    /// Delete the HPQMLS group from storage.
+    /// Delete the APQMLS group from storage.
     pub fn delete<Storage: StorageProvider>(
         &mut self,
         provider: &Storage,

--- a/src/merging.rs
+++ b/src/merging.rs
@@ -7,9 +7,9 @@ use openmls::{
     storage::{OpenMlsProvider, StorageProvider},
 };
 
-use crate::{HpqMlsGroup, processing::HpqStagedCommit};
+use crate::{ApqMlsGroup, processing::ApqStagedCommit};
 
-impl HpqMlsGroup {
+impl ApqMlsGroup {
     /// Merges the pending [`openmls::group::StagedCommit`] of the traditional group, as well as
     /// that of the PQ group if there is one.
     pub fn merge_pending_commit<Provider: OpenMlsProvider>(
@@ -26,9 +26,9 @@ impl HpqMlsGroup {
     pub fn merge_staged_commit<Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
-        staged_commit: HpqStagedCommit,
+        staged_commit: ApqStagedCommit,
     ) -> Result<(), MergeCommitError<Provider::StorageError>> {
-        let HpqStagedCommit {
+        let ApqStagedCommit {
             t_staged_commit,
             pq_staged_commit,
         } = staged_commit;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,60 +15,60 @@ use openmls::{
 use serde::{Deserialize, Serialize};
 use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::{HpqGroupId, authentication::HpqVerifyingKey, extension::PqtMode};
+use crate::{ApqGroupId, authentication::ApqVerifyingKey, extension::PqtMode};
 
-/// An incoming message for processing by an `[HpqMlsGroup]`.
+/// An incoming message for processing by an [`crate::ApqMlsGroup`].
 #[derive(Debug, Clone, TlsDeserialize, TlsSize)]
-pub struct HpqMlsMessageIn {
+pub struct ApqMlsMessageIn {
     pub(crate) t_message: MlsMessageIn,
     pub(crate) pq_message: MlsMessageIn,
 }
 
-impl HpqMlsMessageIn {
-    pub fn into_welcome(self) -> Option<HpqWelcome> {
+impl ApqMlsMessageIn {
+    pub fn into_welcome(self) -> Option<ApqWelcome> {
         let MlsMessageBodyIn::Welcome(t_welcome) = self.t_message.extract() else {
             return None;
         };
         let MlsMessageBodyIn::Welcome(pq_welcome) = self.pq_message.extract() else {
             return None;
         };
-        Some(HpqWelcome {
+        Some(ApqWelcome {
             t_welcome,
             pq_welcome,
         })
     }
 
-    pub fn into_key_package(self) -> Option<HpqKeyPackageIn> {
+    pub fn into_key_package(self) -> Option<ApqKeyPackageIn> {
         let MlsMessageBodyIn::KeyPackage(t_key_package) = self.t_message.extract() else {
             return None;
         };
         let MlsMessageBodyIn::KeyPackage(pq_key_package) = self.pq_message.extract() else {
             return None;
         };
-        Some(HpqKeyPackageIn {
+        Some(ApqKeyPackageIn {
             t_key_package,
             pq_key_package,
         })
     }
 
-    pub fn into_protocol_message(self) -> Option<HpqProtocolMessage> {
+    pub fn into_protocol_message(self) -> Option<ApqProtocolMessage> {
         let t_protocol_message = self.t_message.try_into_protocol_message().ok()?;
         let pq_protocol_message = self.pq_message.try_into_protocol_message().ok()?;
-        Some(HpqProtocolMessage {
+        Some(ApqProtocolMessage {
             t_protocol_message,
             pq_protocol_message,
         })
     }
 }
 
-pub struct HpqProtocolMessage {
+pub struct ApqProtocolMessage {
     pub(crate) t_protocol_message: ProtocolMessage,
     pub(crate) pq_protocol_message: ProtocolMessage,
 }
 
-impl HpqProtocolMessage {
-    pub fn group_id(&self) -> HpqGroupId {
-        HpqGroupId {
+impl ApqProtocolMessage {
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
             t_group_id: self.t_protocol_message.group_id().clone(),
             pq_group_id: self.pq_protocol_message.group_id().clone(),
         }
@@ -83,72 +83,72 @@ impl HpqProtocolMessage {
     }
 }
 
-/// An outgoing message from an `[HpqMlsGroup]`.
+/// An outgoing message from an [`crate::ApqMlsGroup`].
 #[derive(Debug, Clone, TlsSerialize, TlsSize, Serialize, Deserialize)]
-pub struct HpqMlsMessageOut {
+pub struct ApqMlsMessageOut {
     pub(crate) t_message: MlsMessageOut,
     pub(crate) pq_message: MlsMessageOut,
 }
 
-impl TryFrom<HpqMlsMessageOut> for HpqMlsMessageIn {
+impl TryFrom<ApqMlsMessageOut> for ApqMlsMessageIn {
     type Error = tls_codec::Error;
 
-    fn try_from(value: HpqMlsMessageOut) -> Result<Self, Self::Error> {
+    fn try_from(value: ApqMlsMessageOut) -> Result<Self, Self::Error> {
         let serialied_t_message = value.t_message.tls_serialize_detached()?;
         let serialized_pq_message = value.pq_message.tls_serialize_detached()?;
         let t_message_in = MlsMessageIn::tls_deserialize_exact(&serialied_t_message)?;
         let pq_message_in = MlsMessageIn::tls_deserialize_exact(&serialized_pq_message)?;
-        Ok(HpqMlsMessageIn {
+        Ok(ApqMlsMessageIn {
             t_message: t_message_in,
             pq_message: pq_message_in,
         })
     }
 }
 
-/// A welcome message for joining an `[HpqMlsGroup]`.
-pub struct HpqWelcome {
+/// A welcome message for joining an [`crate::ApqMlsGroup`].
+pub struct ApqWelcome {
     pub(crate) t_welcome: Welcome,
     pub(crate) pq_welcome: Welcome,
 }
 
-impl From<HpqWelcome> for HpqMlsMessageOut {
-    fn from(value: HpqWelcome) -> Self {
-        HpqMlsMessageOut {
+impl From<ApqWelcome> for ApqMlsMessageOut {
+    fn from(value: ApqWelcome) -> Self {
+        ApqMlsMessageOut {
             t_message: MlsMessageOut::from_welcome(value.t_welcome, ProtocolVersion::default()),
             pq_message: MlsMessageOut::from_welcome(value.pq_welcome, ProtocolVersion::default()),
         }
     }
 }
 
-/// A ratchet tree for an `[HpqMlsGroup]`.
-pub struct HpqRatchetTree {
+/// A ratchet tree for an [`crate::ApqMlsGroup`].
+pub struct ApqRatchetTree {
     pub(crate) t_ratchet_tree: RatchetTree,
     pub(crate) pq_ratchet_tree: RatchetTree,
 }
 
-impl From<HpqRatchetTree> for HpqRatchetTreeIn {
-    fn from(value: HpqRatchetTree) -> Self {
-        HpqRatchetTreeIn {
+impl From<ApqRatchetTree> for ApqRatchetTreeIn {
+    fn from(value: ApqRatchetTree) -> Self {
+        ApqRatchetTreeIn {
             t_ratchet_tree: value.t_ratchet_tree.into(),
             pq_ratchet_tree: value.pq_ratchet_tree.into(),
         }
     }
 }
 
-/// An unverified ratchet tree for an `[HpqMlsGroup]`.
-pub struct HpqRatchetTreeIn {
+/// An unverified ratchet tree for an [`crate::ApqMlsGroup`].
+pub struct ApqRatchetTreeIn {
     pub(crate) t_ratchet_tree: RatchetTreeIn,
     pub(crate) pq_ratchet_tree: RatchetTreeIn,
 }
 
-/// A key package to add members to an `[HpqMlsGroup]`.
+/// A key package to add members to an [`crate::ApqMlsGroup`].
 #[derive(Debug, Clone)]
-pub struct HpqKeyPackage {
+pub struct ApqKeyPackage {
     pub(crate) t_key_package: KeyPackage,
     pub(crate) pq_key_package: KeyPackage,
 }
 
-impl HpqKeyPackage {
+impl ApqKeyPackage {
     pub fn mode(&self) -> PqtMode {
         match self.pq_key_package.ciphersuite() {
             Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 => PqtMode::ConfAndAuth,
@@ -167,49 +167,49 @@ impl HpqKeyPackage {
     }
 }
 
-impl From<HpqKeyPackage> for HpqMlsMessageOut {
-    fn from(value: HpqKeyPackage) -> Self {
-        HpqMlsMessageOut {
+impl From<ApqKeyPackage> for ApqMlsMessageOut {
+    fn from(value: ApqKeyPackage) -> Self {
+        ApqMlsMessageOut {
             t_message: MlsMessageOut::from(value.t_key_package),
             pq_message: MlsMessageOut::from(value.pq_key_package),
         }
     }
 }
 
-/// An unverified key package for adding members to an `[HpqMlsGroup]`.
-pub struct HpqKeyPackageIn {
+/// An unverified key package for adding members to an [`crate::ApqMlsGroup`].
+pub struct ApqKeyPackageIn {
     pub(crate) t_key_package: KeyPackageIn,
     pub(crate) pq_key_package: KeyPackageIn,
 }
 
-/// The group info of an `[HpqMlsGroup]`.
-pub struct HpqGroupInfo {
+/// The group info of an [`crate::ApqMlsGroup`].
+pub struct ApqGroupInfo {
     pub(crate) t_group_info: GroupInfo,
     pub(crate) pq_group_info: GroupInfo,
 }
 
-impl From<HpqGroupInfo> for HpqMlsMessageOut {
-    fn from(value: HpqGroupInfo) -> Self {
-        HpqMlsMessageOut {
+impl From<ApqGroupInfo> for ApqMlsMessageOut {
+    fn from(value: ApqGroupInfo) -> Self {
+        ApqMlsMessageOut {
             t_message: MlsMessageOut::from(value.t_group_info),
             pq_message: MlsMessageOut::from(value.pq_group_info),
         }
     }
 }
 
-/// A verifiable group info for an `[HpqMlsGroup]`.
-pub struct VerifiableHpqGroupInfo {
+/// A verifiable group info for an [`crate::ApqMlsGroup`].
+pub struct VerifiableApqGroupInfo {
     pub(crate) t_group_info: VerifiableGroupInfo,
     pub(crate) pq_group_info: VerifiableGroupInfo,
 }
 
-impl VerifiableHpqGroupInfo {
-    /// Verifies the group info and returns the contained [`HpqGroupInfo`].
+impl VerifiableApqGroupInfo {
+    /// Verifies the group info and returns the contained [`ApqGroupInfo`].
     pub fn verify(
         self,
         provider: &impl OpenMlsCrypto,
-        verifying_key: &HpqVerifyingKey,
-    ) -> Result<HpqGroupInfo, SignatureError> {
+        verifying_key: &ApqVerifyingKey,
+    ) -> Result<ApqGroupInfo, SignatureError> {
         let t_verifying_key = OpenMlsSignaturePublicKey::from_signature_key(
             verifying_key.t_verifying_key.clone(),
             self.t_group_info.ciphersuite().signature_algorithm(),
@@ -218,7 +218,7 @@ impl VerifiableHpqGroupInfo {
             verifying_key.pq_verifying_key.clone(),
             self.pq_group_info.ciphersuite().signature_algorithm(),
         );
-        Ok(HpqGroupInfo {
+        Ok(ApqGroupInfo {
             t_group_info: self.t_group_info.verify(provider, &t_verifying_key)?,
             pq_group_info: self.pq_group_info.verify(provider, &pq_verifying_key)?,
         })

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -18,28 +18,28 @@ use thiserror::Error;
 use tls_codec::Serialize;
 
 use crate::{
-    HpqMlsGroup,
-    extension::{HPQMLS_EXTENSION_ID, HpqMlsInfo},
-    messages::HpqProtocolMessage,
-    psk::{HpqPskError, HpqPskId, store_psk},
+    ApqMlsGroup,
+    extension::{APQMLS_EXTENSION_ID, ApqMlsInfo},
+    messages::ApqProtocolMessage,
+    psk::{ApqPskError, ApqPskId, store_psk},
 };
 
 /// A bundle consisting of the processed messages of both the traditional and
 /// the PQ group.
-pub struct HpqProcessedMessage {
+pub struct ApqProcessedMessage {
     pub t_message: ProcessedMessage,
     pub pq_message: ProcessedMessage,
 }
 
 /// A bundle consisting of the staged commits of both the traditional and the
 /// PQ group.
-pub struct HpqStagedCommit {
+pub struct ApqStagedCommit {
     pub t_staged_commit: StagedCommit,
     pub pq_staged_commit: StagedCommit,
 }
 
-impl HpqProcessedMessage {
-    pub fn into_staged_commit(self) -> Option<HpqStagedCommit> {
+impl ApqProcessedMessage {
+    pub fn into_staged_commit(self) -> Option<ApqStagedCommit> {
         let t_staged_commit = match self.t_message.into_content() {
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => *staged_commit,
             _ => return None,
@@ -48,28 +48,28 @@ impl HpqProcessedMessage {
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => *staged_commit,
             _ => return None,
         };
-        Some(HpqStagedCommit {
+        Some(ApqStagedCommit {
             t_staged_commit,
             pq_staged_commit,
         })
     }
 }
 
-/// Errors that can occur when processing a message with an [`HpqMlsGroup`].
+/// Errors that can occur when processing a message with an [`ApqMlsGroup`].
 #[derive(Debug, Error)]
-pub enum HpqProcessMessageError<StorageError> {
+pub enum ApqProcessMessageError<StorageError> {
     #[error("Failed to process message: {0}")]
     Processing(#[from] ProcessMessageError<StorageError>),
     #[error(transparent)]
-    Psk(#[from] HpqPskError<StorageError>),
+    Psk(#[from] ApqPskError<StorageError>),
     #[error("The message type is invalid for processing.")]
     InvalidMessageType,
     #[error("The MLS messages don't match.")]
     MismatchedMessages,
-    #[error("HPQMLSInfo extension is missing or invalid in commit message.")]
-    MissingHpqMlsInfo,
-    #[error("HPQMLSInfo extension content is invalid.")]
-    InvalidHpqMlsInfo,
+    #[error("APQMLSInfo extension is missing or invalid in commit message.")]
+    MissingApqMlsInfo,
+    #[error("APQMLSInfo extension content is invalid.")]
+    InvalidApqMlsInfo,
 }
 
 #[derive(Eq)]
@@ -256,7 +256,7 @@ impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for MessageInfo<F> {
     }
 }
 
-impl HpqMlsGroup {
+impl ApqMlsGroup {
     /// Parses incoming messages from the DS. Checks for syntactic errors and
     /// makes some semantic checks as well. If the input is an encrypted
     /// message, it will be decrypted. This processing function does syntactic
@@ -269,20 +269,20 @@ impl HpqMlsGroup {
     pub fn process_message<F, Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
-        message: impl Into<HpqProtocolMessage>,
+        message: impl Into<ApqProtocolMessage>,
         sender_equivalence: F,
-    ) -> Result<HpqProcessedMessage, HpqProcessMessageError<Provider::StorageError>>
+    ) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
     where
         F: Fn(&Credential, &Credential) -> bool,
     {
-        let protocol_message: HpqProtocolMessage = message.into();
+        let protocol_message: ApqProtocolMessage = message.into();
         // We only export a PSK if we process a PQ message
         let mut pq_message = self
             .pq_group
             .process_message(provider, protocol_message.pq_protocol_message)?;
 
         let msg_type = MessageType::new(pq_message.content(), &sender_equivalence)
-            .ok_or(HpqProcessMessageError::InvalidMessageType)?;
+            .ok_or(ApqProcessMessageError::InvalidMessageType)?;
         let pq_message_info = MessageInfo {
             msg_type,
             sender: pq_message.sender().clone(),
@@ -294,20 +294,20 @@ impl HpqMlsGroup {
             ProcessedMessageContent::StagedCommitMessage(_)
         ) {
             let psk_value = pq_message
-                .safe_export_secret(provider.crypto(), HPQMLS_EXTENSION_ID)
-                .map_err(HpqPskError::ExportFromProcessed)?;
+                .safe_export_secret(provider.crypto(), APQMLS_EXTENSION_ID)
+                .map_err(ApqPskError::ExportFromProcessed)?;
 
             let next_epoch = self.pq_group.epoch().as_u64() + 1;
-            HpqPskId {
+            ApqPskId {
                 group_id: self.pq_group.group_id().clone(),
                 epoch: next_epoch,
             }
             .tls_serialize_detached()
-            .map_err(HpqPskError::SerializingPskId)?
+            .map_err(ApqPskError::SerializingPskId)?
             .pipe(ExternalPsk::new)
             .pipe(Psk::External)
             .pipe(|psk| PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk))
-            .map_err(HpqPskError::DerivingPskId)?
+            .map_err(ApqPskError::DerivingPskId)?
             .pipe(|id| store_psk(provider, id, &psk_value))?;
         }
 
@@ -316,7 +316,7 @@ impl HpqMlsGroup {
             .process_message(provider, protocol_message.t_protocol_message)?;
 
         let msg_type = MessageType::new(t_message.content(), &sender_equivalence)
-            .ok_or(HpqProcessMessageError::InvalidMessageType)?;
+            .ok_or(ApqProcessMessageError::InvalidMessageType)?;
         let t_message_info = MessageInfo {
             msg_type,
             sender: t_message.sender().clone(),
@@ -324,23 +324,23 @@ impl HpqMlsGroup {
 
         // Make sure that messages match up
         if pq_message_info != t_message_info {
-            return Err(HpqProcessMessageError::MismatchedMessages);
+            return Err(ApqProcessMessageError::MismatchedMessages);
         }
 
-        // If both are commits, the HPQMLSInfo extension must be updated and in
+        // If both are commits, the APQMLSInfo extension must be updated and in
         // line with the info of both groups
         if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
             && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) =
                 t_message.content()
         {
             let pq_extension =
-                HpqMlsInfo::from_extensions(pq_staged_commit.group_context().extensions())
-                    .map_err(|_| HpqProcessMessageError::MissingHpqMlsInfo)?
-                    .ok_or(HpqProcessMessageError::MissingHpqMlsInfo)?;
+                ApqMlsInfo::from_extensions(pq_staged_commit.group_context().extensions())
+                    .map_err(|_| ApqProcessMessageError::MissingApqMlsInfo)?
+                    .ok_or(ApqProcessMessageError::MissingApqMlsInfo)?;
             let t_extension =
-                HpqMlsInfo::from_extensions(t_staged_commit.group_context().extensions())
-                    .map_err(|_| HpqProcessMessageError::MissingHpqMlsInfo)?
-                    .ok_or(HpqProcessMessageError::MissingHpqMlsInfo)?;
+                ApqMlsInfo::from_extensions(t_staged_commit.group_context().extensions())
+                    .map_err(|_| ApqProcessMessageError::MissingApqMlsInfo)?
+                    .ok_or(ApqProcessMessageError::MissingApqMlsInfo)?;
 
             // Extension contents must match
             let extensions_match = pq_extension == t_extension;
@@ -373,11 +373,11 @@ impl HpqMlsGroup {
                 || !ciphersuites_match
                 || !ciphersuite_matches_mode
             {
-                return Err(HpqProcessMessageError::InvalidHpqMlsInfo);
+                return Err(ApqProcessMessageError::InvalidApqMlsInfo);
             }
         }
 
-        Ok(HpqProcessedMessage {
+        Ok(ApqProcessedMessage {
             t_message,
             pq_message,
         })

--- a/src/psk.rs
+++ b/src/psk.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! This module defines types and functions for handling Pre-Shared Keys (PSKs)
-//! in HPQMLS.
+//! in APQMLS.
 
 use openmls::{
     group::{
@@ -19,11 +19,11 @@ use tap::Pipe as _;
 use thiserror::Error;
 use tls_codec::{Serialize as _, TlsSerialize, TlsSize};
 
-use crate::extension::HPQMLS_EXTENSION_ID;
+use crate::extension::APQMLS_EXTENSION_ID;
 
-/// Error while handling PSKs in HPQMLS.
+/// Error while handling PSKs in APQMLS.
 #[derive(Debug, Error)]
-pub enum HpqPskError<StorageError> {
+pub enum ApqPskError<StorageError> {
     #[error(transparent)]
     ExportFromGroup(#[from] SafeExportSecretError<StorageError>),
     #[error(transparent)]
@@ -38,10 +38,10 @@ pub enum HpqPskError<StorageError> {
     SerializingPskId(#[from] tls_codec::Error),
 }
 
-/// The ID of a PSK in HPQMLS, consisting of the group ID and epoch of the PQ
+/// The ID of a PSK in APQMLS, consisting of the group ID and epoch of the PQ
 /// group.
 #[derive(Debug, Clone, TlsSize, TlsSerialize)]
-pub(crate) struct HpqPskId {
+pub(crate) struct ApqPskId {
     pub(crate) group_id: GroupId,
     pub(crate) epoch: u64,
 }
@@ -54,22 +54,22 @@ pub(crate) fn derive_and_store_psk<
     group: &mut MlsGroup,
     t_ciphersuite: Ciphersuite,
     //ciphersuite: Ciphersuite,
-) -> Result<PreSharedKeyId, HpqPskError<Provider::StorageError>> {
+) -> Result<PreSharedKeyId, ApqPskError<Provider::StorageError>> {
     let (psk_value, epoch) = if FROM_PENDING {
         let psk_value = group.safe_export_secret_from_pending(
             provider.crypto(),
             provider.storage(),
-            HPQMLS_EXTENSION_ID,
+            APQMLS_EXTENSION_ID,
         )?;
         let epoch = group.epoch().as_u64() + 1;
         (psk_value, epoch)
     } else {
         let psk_value =
-            group.safe_export_secret(provider.crypto(), provider.storage(), HPQMLS_EXTENSION_ID)?;
+            group.safe_export_secret(provider.crypto(), provider.storage(), APQMLS_EXTENSION_ID)?;
         (psk_value, group.epoch().as_u64())
     };
     // Prepare the PSK for the T group.
-    HpqPskId {
+    ApqPskId {
         group_id: group.group_id().clone(),
         epoch,
     }
@@ -84,12 +84,12 @@ pub(crate) fn store_psk<Provider: OpenMlsProvider>(
     provider: &Provider,
     psk_id: PreSharedKeyId,
     psk: &[u8],
-) -> Result<PreSharedKeyId, HpqPskError<Provider::StorageError>> {
+) -> Result<PreSharedKeyId, ApqPskError<Provider::StorageError>> {
     // Delete any existing PSK with the same ID.
     provider
         .storage()
         .delete_psk::<Psk>(psk_id.psk())
-        .map_err(|_| HpqPskError::Psk(PskError::Storage))?;
+        .map_err(|_| ApqPskError::Psk(PskError::Storage))?;
     psk_id.store(provider, psk)?;
     Ok(psk_id)
 }

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -9,35 +9,35 @@ use openmls::{
 use thiserror::Error;
 
 use crate::{
-    HpqMlsGroup,
-    messages::{HpqRatchetTreeIn, HpqWelcome},
-    psk::{HpqPskError, derive_and_store_psk},
+    ApqMlsGroup,
+    messages::{ApqRatchetTreeIn, ApqWelcome},
+    psk::{ApqPskError, derive_and_store_psk},
 };
 
-/// Errors that can occur when creating a new [`HpqMlsGroup`] from a welcome
+/// Errors that can occur when creating a new [`ApqMlsGroup`] from a welcome
 /// message.
 #[derive(Debug, Error)]
 pub enum WelcomeError<StorageError> {
     #[error("Failed to process welcome message: {0}")]
     Processing(#[from] OpenMlsWelcomeError<StorageError>),
     #[error(transparent)]
-    Psk(#[from] HpqPskError<StorageError>),
+    Psk(#[from] ApqPskError<StorageError>),
 }
 
-/// A staged HPQ welcome.
-pub struct StagedHpqWelcome {
+/// A staged APQ welcome.
+pub struct StagedApqWelcome {
     t_staged_welcome: StagedWelcome,
     pq_staged_welcome: StagedWelcome,
 }
 
-impl HpqMlsGroup {
-    /// Creates a new [`HpqMlsGroup`] from a welcome message.
+impl ApqMlsGroup {
+    /// Creates a new [`ApqMlsGroup`] from a welcome message.
     // TODO: Split into sans-io friendly parts.
     pub fn new_from_welcome<Provider: OpenMlsProvider>(
         provider: &Provider,
         mls_group_config: &MlsGroupJoinConfig,
-        welcome: HpqWelcome,
-        ratchet_tree: Option<HpqRatchetTreeIn>,
+        welcome: ApqWelcome,
+        ratchet_tree: Option<ApqRatchetTreeIn>,
     ) -> Result<Self, WelcomeError<Provider::StorageError>> {
         let (t_ratchet_tree, pq_ratchet_tree) = match ratchet_tree {
             Some(r) => (Some(r.t_ratchet_tree), Some(r.pq_ratchet_tree)),
@@ -67,13 +67,13 @@ impl HpqMlsGroup {
     }
 }
 
-impl StagedHpqWelcome {
-    /// Creates a new [`StagedHpqWelcome`] from a welcome message.
+impl StagedApqWelcome {
+    /// Creates a new [`StagedApqWelcome`] from a welcome message.
     pub fn new_from_welcome<Provider: OpenMlsProvider>(
         provider: &Provider,
         mls_group_config: &MlsGroupJoinConfig,
-        welcome: HpqWelcome,
-        ratchet_tree: Option<HpqRatchetTreeIn>,
+        welcome: ApqWelcome,
+        ratchet_tree: Option<ApqRatchetTreeIn>,
     ) -> Result<Self, WelcomeError<Provider::StorageError>> {
         let (t_ratchet_tree, pq_ratchet_tree) = match ratchet_tree {
             Some(r) => (Some(r.t_ratchet_tree), Some(r.pq_ratchet_tree)),
@@ -92,20 +92,20 @@ impl StagedHpqWelcome {
             pq_ratchet_tree,
         )?;
 
-        Ok(StagedHpqWelcome {
+        Ok(StagedApqWelcome {
             t_staged_welcome,
             pq_staged_welcome,
         })
     }
 
-    /// Consumes the staged welcome and creates a new [`HpqMlsGroup`].
+    /// Consumes the staged welcome and creates a new [`ApqMlsGroup`].
     pub fn into_group<Provider: OpenMlsProvider>(
         self,
         provider: &Provider,
-    ) -> Result<HpqMlsGroup, WelcomeError<Provider::StorageError>> {
+    ) -> Result<ApqMlsGroup, WelcomeError<Provider::StorageError>> {
         let t_group = self.t_staged_welcome.into_group(provider)?;
         let pq_group = self.pq_staged_welcome.into_group(provider)?;
 
-        Ok(HpqMlsGroup { t_group, pq_group })
+        Ok(ApqMlsGroup { t_group, pq_group })
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use hpqmls::{
-    HpqMlsGroup, authentication::HpqSigner as _, extension::PqtMode, messages::HpqMlsMessageIn,
+use apqmls::{
+    ApqMlsGroup, authentication::ApqSigner, extension::PqtMode, messages::ApqMlsMessageIn,
 };
 use openmls::{
     group::{GroupId, MlsGroupJoinConfig},
@@ -25,8 +25,8 @@ fn join_group_helper(mode: PqtMode) -> JoinedGroup {
     let alice = Client::new("Alice", ciphersuite.into(), OpenMlsRustCrypto::default());
     let bob = Client::new("Bob", ciphersuite.into(), OpenMlsRustCrypto::default());
 
-    // Create a new HpqMlsGroup for Alice
-    let mut alice_group = HpqMlsGroup::builder()
+    // Create a new ApqMlsGroup for Alice
+    let mut alice_group = ApqMlsGroup::builder()
         .with_group_ids(
             GroupId::random(alice.provider.rand()),
             GroupId::from_slice(b"test_pq_group"),
@@ -55,7 +55,7 @@ fn join_group_helper(mode: PqtMode) -> JoinedGroup {
 
     // Bob joins Alice's group
     let welcome = commit_bundle.into_welcome().unwrap();
-    let mut bob_group = HpqMlsGroup::new_from_welcome(
+    let mut bob_group = ApqMlsGroup::new_from_welcome(
         &bob.provider,
         &MlsGroupJoinConfig::default(),
         welcome,
@@ -89,7 +89,7 @@ fn update_group_helper(group: JoinedGroup) -> JoinedGroup {
         .unwrap();
     alice_group.merge_pending_commit(&alice.provider).unwrap();
 
-    let message_in = HpqMlsMessageIn::try_from(alice_commit_bundle.commit).unwrap();
+    let message_in = ApqMlsMessageIn::try_from(alice_commit_bundle.commit).unwrap();
     let protocol_message = message_in.into_protocol_message().unwrap();
 
     // Bob processes Alice's update
@@ -116,8 +116,8 @@ fn update_group_helper(group: JoinedGroup) -> JoinedGroup {
 struct JoinedGroup {
     alice: Client<OpenMlsRustCrypto>,
     bob: Client<OpenMlsRustCrypto>,
-    alice_group: HpqMlsGroup,
-    bob_group: HpqMlsGroup,
+    alice_group: ApqMlsGroup,
+    bob_group: ApqMlsGroup,
 }
 
 const TEST_MODE: [PqtMode; 2] = [PqtMode::ConfAndAuth, PqtMode::ConfOnly];
@@ -214,7 +214,7 @@ fn t_only_update() {
 
         assert_groups_eq(&mut alice_group, &mut bob_group);
 
-        // Do an HPQMLS update to make sure everything still works
+        // Do an APQMLS update to make sure everything still works
         let joined_group = JoinedGroup {
             alice,
             bob,

--- a/tests/utils/client.rs
+++ b/tests/utils/client.rs
@@ -2,23 +2,23 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use hpqmls::{
-    HpqCiphersuite,
-    authentication::{HpqCredentialWithKey, HpqSignatureKeyPair, HpqSignatureScheme},
-    messages::HpqKeyPackage,
+use apqmls::{
+    ApqCiphersuite,
+    authentication::{ApqCredentialWithKey, ApqSignatureKeyPair, ApqSignatureScheme},
+    messages::ApqKeyPackage,
 };
 use openmls::storage::OpenMlsProvider;
 
 pub struct Client<Provider> {
-    pub signer: HpqSignatureKeyPair,
-    pub credential_with_key: HpqCredentialWithKey,
+    pub signer: ApqSignatureKeyPair,
+    pub credential_with_key: ApqCredentialWithKey,
     pub provider: Provider,
 }
 
 impl<Provider: OpenMlsProvider> Client<Provider> {
-    pub fn new(identity: &str, signature_scheme: HpqSignatureScheme, provider: Provider) -> Self {
-        let keypair = HpqSignatureKeyPair::new(signature_scheme).unwrap();
-        let credential_with_key = HpqCredentialWithKey::new(identity.as_bytes(), &keypair);
+    pub fn new(identity: &str, signature_scheme: ApqSignatureScheme, provider: Provider) -> Self {
+        let keypair = ApqSignatureKeyPair::new(signature_scheme).unwrap();
+        let credential_with_key = ApqCredentialWithKey::new(identity.as_bytes(), &keypair);
 
         Client {
             signer: keypair,
@@ -27,8 +27,8 @@ impl<Provider: OpenMlsProvider> Client<Provider> {
         }
     }
 
-    pub fn generate_key_package(&self, ciphersuite: HpqCiphersuite) -> HpqKeyPackage {
-        HpqKeyPackage::builder()
+    pub fn generate_key_package(&self, ciphersuite: ApqCiphersuite) -> ApqKeyPackage {
+        ApqKeyPackage::builder()
             .build(
                 &self.provider,
                 ciphersuite,

--- a/tests/utils/client.rs
+++ b/tests/utils/client.rs
@@ -27,11 +27,11 @@ impl<Provider: OpenMlsProvider> Client<Provider> {
         }
     }
 
-    pub fn generate_key_package(&self, cipersuite: HpqCiphersuite) -> HpqKeyPackage {
+    pub fn generate_key_package(&self, ciphersuite: HpqCiphersuite) -> HpqKeyPackage {
         HpqKeyPackage::builder()
             .build(
                 &self.provider,
-                cipersuite,
+                ciphersuite,
                 &self.signer,
                 self.credential_with_key.clone(),
             )

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use hpqmls::HpqMlsGroup;
+use apqmls::ApqMlsGroup;
 
 pub mod client;
 
-pub fn assert_groups_eq(group1: &mut HpqMlsGroup, group2: &mut HpqMlsGroup) {
+pub fn assert_groups_eq(group1: &mut ApqMlsGroup, group2: &mut ApqMlsGroup) {
     let t_group_1_authenticator = group1.t_group.epoch_authenticator();
     let t_group_2_authenticator = group2.t_group.epoch_authenticator();
     assert_eq!(


### PR DESCRIPTION
- hpke-rs is patched to support p384 curve
- openmls is patched to support post-quantum ciphersuites

Additionally:
* chore: rename HQPMLS to APQMLS (#8)