### PR TITLE
chore: migrate APQInfo from group extension to component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "log",
  "openmls_libcrux_crypto",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "hex",
  "log",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "log",
  "openmls_traits",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls.git?rev=c71df9295f54c7fba9b56451a06edbba96bf651e#c71df9295f54c7fba9b56451a06edbba96bf651e"
+source = "git+https://github.com/boxdot/openmls.git?rev=6dbc03016f2f0c33d1a358d5427c2d6075f1da34#6dbc03016f2f0c33d1a358d5427c2d6075f1da34"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -1704,9 +1704,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1724,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c427f2572afe5c6cbfa2b1bf40071c89bf1a8539e958ea582842f6f38dcfae"
+checksum = "ee5133e5b207e5703c2a4a9dc9bd8c8f2cc74c4ac04ca5510acaa907012c77ac"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702655abfc67f93a6f735e9fa4ace7d2e580633f8961f28acbfd7583ddce936c"
+checksum = "023a2a96d959c9b5b5da78e965bfdb1363b365bf5e84531a67d0eee827a702a3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5145756cdf293b5089dc6b4f103f1a1229cc55d67082c866f8c8289531c4b983"
+checksum = "c56c2e960c8e47c7c5c30ad334afea8b5502da796a59e34d640d6239d876d924"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2206,9 +2206,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git" }
 [patch."https://github.com/openmls/openmls.git"]
 # feat: Post-Quantum Cryptography support (ML-KEM + ML-DSA)
 # <https://github.com/openmls/openmls/pull/1994>
-openmls = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
-openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
-openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
-openmls_traits = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
-openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", rev = "c71df9295f54c7fba9b56451a06edbba96bf651e" }
+openmls = { git = "https://github.com/boxdot/openmls.git", rev = "6dbc03016f2f0c33d1a358d5427c2d6075f1da34" }
+openmls_basic_credential = { git = "https://github.com/boxdot/openmls.git", rev = "6dbc03016f2f0c33d1a358d5427c2d6075f1da34" }
+openmls_rust_crypto = { git = "https://github.com/boxdot/openmls.git", rev = "6dbc03016f2f0c33d1a358d5427c2d6075f1da34" }
+openmls_traits = { git = "https://github.com/boxdot/openmls.git", rev = "6dbc03016f2f0c33d1a358d5427c2d6075f1da34" }
+openmls_memory_storage = { git = "https://github.com/boxdot/openmls.git", rev = "6dbc03016f2f0c33d1a358d5427c2d6075f1da34" }
 
 [patch.crates-io]
 # feat: add p384 support

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -8,8 +8,8 @@ use openmls::{
         CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, QueuedProposal,
     },
     prelude::{
-        InvalidExtensionError, LeafNodeIndex, LeafNodeParameters, PreSharedKeyProposal, Proposal,
-        ProposalType,
+        AppDataUpdateProposal, InvalidExtensionError, LeafNodeIndex, LeafNodeParameters,
+        PreSharedKeyProposal, Proposal, ProposalType,
     },
     storage::OpenMlsProvider,
 };
@@ -19,6 +19,7 @@ use thiserror::Error;
 use crate::{
     ApqMlsGroup,
     authentication::ApqSigner,
+    extension::APQMLS_COMPONENT_ID,
     messages::{ApqGroupInfo, ApqKeyPackage, ApqMlsMessageOut, ApqWelcome},
     psk::{ApqPskError, derive_and_store_psk},
 };
@@ -241,28 +242,36 @@ impl<'a> CommitBuilder<'a> {
         t_f: impl FnMut(&QueuedProposal) -> bool,
         pq_f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<ApqCommitMessageBundle, CreateCommitError<Provider::StorageError>> {
-        let mut current_apq_info = self
+        let mut apq_info = self
             .group
             .apq_info()
             .ok_or_else(|| CreateCommitError::MissingApqInfo)?;
         let new_t_epoch = self.group.t_group.epoch().as_u64() + 1;
         let new_pq_epoch = self.group.pq_group.epoch().as_u64() + 1;
-        current_apq_info.set_epoch(
+        apq_info.set_epoch(
             GroupEpoch::from(new_t_epoch),
             GroupEpoch::from(new_pq_epoch),
         );
 
-        let mut current_extensions = self.group.t_group.extensions().clone();
-        current_extensions.add_or_replace(current_apq_info.to_extension()?)?;
+        let apq_info_component_data = apq_info.to_component_data()?;
+        let app_data_update_proposal =
+            AppDataUpdateProposal::update(APQMLS_COMPONENT_ID, apq_info_component_data.data());
 
         // Create the PQ commit first s.t. we can export the PSK for the T group.
-        let pq_result = self
+        let mut pq_builder = self
             .group
             .pq_group
             .commit_builder()
             .pipe(|b| self.values.apply::<false>(b))
-            .propose_group_context_extensions(current_extensions.clone())?
-            .load_psks(provider.storage())?
+            .add_proposal(Proposal::AppDataUpdate(Box::new(
+                app_data_update_proposal.clone(),
+            )))
+            .load_psks(provider.storage())?;
+        let mut updater = pq_builder.app_data_dictionary_updater();
+        updater.set(apq_info_component_data.clone());
+        let changes = updater.changes();
+        pq_builder.with_app_data_dictionary_updates(changes);
+        let pq_result = pq_builder
             .build(provider.rand(), provider.crypto(), signer.pq_signer(), pq_f)?
             .stage_commit(provider)?;
 
@@ -276,14 +285,19 @@ impl<'a> CommitBuilder<'a> {
         .pipe(Box::new)
         .pipe(Proposal::PreSharedKey);
 
-        let t_result = self
+        let mut t_builder = self
             .group
             .t_group
             .commit_builder()
             .pipe(|b| self.values.apply::<true>(b))
             .add_proposal(psk_proposal)
-            .propose_group_context_extensions(current_extensions)?
-            .load_psks(provider.storage())?
+            .add_proposal(Proposal::AppDataUpdate(Box::new(app_data_update_proposal)))
+            .load_psks(provider.storage())?;
+        let mut updater = t_builder.app_data_dictionary_updater();
+        updater.set(apq_info_component_data);
+        let changes = updater.changes();
+        t_builder.with_app_data_dictionary_updates(changes);
+        let t_result = t_builder
             .build(provider.rand(), provider.crypto(), signer.t_signer(), t_f)?
             .stage_commit(provider)?;
         Ok(ApqCommitMessageBundle::from_bundles(t_result, pq_result))

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -3,16 +3,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
+    component::{ComponentData, ComponentId, ComponentType},
     group::{GroupContext, GroupEpoch, GroupId},
-    prelude::{Capabilities, Ciphersuite, Extension, ExtensionType, Extensions, UnknownExtension},
+    prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Capabilities, Ciphersuite, Extension,
+        ExtensionType, Extensions, LeafNode, ProposalType,
+    },
 };
 use tap::Pipe;
 use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
 use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup};
 
-pub const APQMLS_EXTENSION_ID: u16 = 0xFF01;
-pub const APQMLS_EXTENSION_TYPE: ExtensionType = ExtensionType::Unknown(APQMLS_EXTENSION_ID);
+/// The component ID of the APQMLS component.
+///
+/// The value is not yet finalized in the draft
+/// <https://datatracker.ietf.org/doc/html/draft-ietf-mls-combiner#name-key-schedule>.
+pub const APQMLS_COMPONENT_ID: ComponentId = 0x8001;
 
 /// The mode of an [`ApqMlsGroup`], which determines whether only confidentiality or both
 /// confidentiality and authentication is PQ secure.
@@ -46,7 +53,7 @@ impl PqtMode {
 /// The APQMLS extension, which is used to store APQMLS-specific information
 /// in the extensions of an [`openmls::group::MlsGroup`].
 #[derive(Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, PartialEq, Eq)]
-pub struct ApqMlsInfo {
+pub struct ApqInfo {
     pub t_session_group_id: GroupId,
     pub pq_session_group_id: GroupId,
     pub mode: PqtMode,
@@ -56,12 +63,10 @@ pub struct ApqMlsInfo {
     pub pq_epoch: GroupEpoch,
 }
 
-impl ApqMlsInfo {
-    pub(super) fn to_extension(&self) -> Result<Extension, tls_codec::Error> {
-        self.tls_serialize_detached()?
-            .pipe(UnknownExtension)
-            .pipe(|extension| Extension::Unknown(APQMLS_EXTENSION_ID, extension))
-            .pipe(Ok)
+impl ApqInfo {
+    pub(super) fn to_component_data(&self) -> Result<ComponentData, tls_codec::Error> {
+        let bytes = self.tls_serialize_detached()?;
+        Ok(ComponentData::from_parts(APQMLS_COMPONENT_ID, bytes.into()))
     }
 
     pub(super) fn set_epoch(&mut self, t_epoch: GroupEpoch, pq_epoch: GroupEpoch) {
@@ -72,14 +77,11 @@ impl ApqMlsInfo {
     pub fn from_extensions(
         extensions: &Extensions<GroupContext>,
     ) -> Result<Option<Self>, tls_codec::Error> {
-        if let Some(extension) = extensions.unknown(APQMLS_EXTENSION_ID) {
-            extension
-                .0
-                .pipe_as_ref::<'_, [u8], _>(ApqMlsInfo::tls_deserialize_exact)
-                .map(Some)
-        } else {
-            Ok(None)
-        }
+        extensions
+            .app_data_dictionary()
+            .and_then(|dict| dict.dictionary().get(&APQMLS_COMPONENT_ID))
+            .map(ApqInfo::tls_deserialize_exact)
+            .transpose()
     }
 
     pub fn group_id(&self) -> ApqGroupId {
@@ -94,12 +96,17 @@ pub(super) fn ensure_extension_support(
     capabilities: Capabilities,
 ) -> Result<Capabilities, tls_codec::Error> {
     let mut extensions = capabilities.extensions().to_vec();
-    if !extensions.contains(&APQMLS_EXTENSION_TYPE) {
-        extensions.push(APQMLS_EXTENSION_TYPE);
-    }
     if !extensions.contains(&ExtensionType::RequiredCapabilities) {
         extensions.push(ExtensionType::RequiredCapabilities);
     }
+    if !extensions.contains(&ExtensionType::AppDataDictionary) {
+        extensions.push(ExtensionType::AppDataDictionary);
+    }
+    let mut proposals: Vec<ProposalType> = capabilities.proposals().to_vec();
+    if !proposals.contains(&ProposalType::AppDataUpdate) {
+        proposals.push(ProposalType::AppDataUpdate);
+    }
+
     let ciphersuites: Vec<Ciphersuite> = capabilities
         .ciphersuites()
         .iter()
@@ -109,15 +116,53 @@ pub(super) fn ensure_extension_support(
         Some(capabilities.versions()),
         Some(&ciphersuites),
         Some(extensions.as_slice()),
-        Some(capabilities.proposals()),
+        Some(proposals.as_slice()),
         Some(capabilities.credentials()),
     )
     .pipe(Ok)
 }
 
+pub(super) fn ensure_component_support(
+    mut dictionary: AppDataDictionary,
+) -> Result<AppDataDictionary, tls_codec::Error> {
+    dictionary.insert(
+        ComponentId::from(ComponentType::AppComponents),
+        [APQMLS_COMPONENT_ID].as_slice().tls_serialize_detached()?,
+    );
+    Ok(dictionary)
+}
+
+pub(super) fn ensure_leaf_node_component_support(
+    mut extensions: Extensions<LeafNode>,
+) -> Result<Extensions<LeafNode>, tls_codec::Error> {
+    let mut dictionary = extensions
+        .app_data_dictionary()
+        .map(|extension| extension.dictionary().clone())
+        .unwrap_or_default();
+    let mut app_components: Vec<ComponentId> = dictionary
+        .get(&ComponentId::from(ComponentType::AppComponents))
+        .map(Vec::tls_deserialize_exact)
+        .transpose()?
+        .unwrap_or_default();
+
+    if !app_components.contains(&APQMLS_COMPONENT_ID) {
+        app_components.push(APQMLS_COMPONENT_ID);
+        dictionary.insert(
+            ComponentId::from(ComponentType::AppComponents),
+            app_components.tls_serialize_detached()?,
+        );
+        let extension = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+        extensions
+            .add_or_replace(extension)
+            .expect("logic error: extension is valid");
+    }
+
+    Ok(extensions)
+}
+
 impl ApqMlsGroup {
-    /// Get the APQMLS extension from the group, if it exists.
-    pub fn apq_info(&self) -> Option<ApqMlsInfo> {
-        ApqMlsInfo::from_extensions(self.t_group.extensions()).ok()?
+    /// Get the APQMLS component from the group, if it exists.
+    pub fn apq_info(&self) -> Option<ApqInfo> {
+        ApqInfo::from_extensions(self.t_group.extensions()).ok()?
     }
 }

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -8,8 +8,9 @@ use openmls::{
         WireFormatPolicy,
     },
     prelude::{
-        Capabilities, Extension, ExtensionType, Extensions, InvalidExtensionError, LeafNode,
-        Lifetime, RequiredCapabilitiesExtension, SenderRatchetConfiguration,
+        AppDataDictionary, AppDataDictionaryExtension, Capabilities, Extension, ExtensionType,
+        Extensions, InvalidExtensionError, LeafNode, Lifetime, ProposalType,
+        RequiredCapabilitiesExtension, SenderRatchetConfiguration,
     },
     storage::OpenMlsProvider,
     treesync::errors::LeafNodeValidationError,
@@ -20,7 +21,7 @@ use thiserror::Error;
 use crate::{
     ApqCiphersuite, ApqGroupId, ApqMlsGroup,
     authentication::{ApqCredentialWithKey, ApqSigner},
-    extension::{APQMLS_EXTENSION_TYPE, ApqMlsInfo, PqtMode, ensure_extension_support},
+    extension::{ApqInfo, PqtMode, ensure_component_support, ensure_extension_support},
     key_package::ensure_ciphersuite_support,
 };
 
@@ -100,8 +101,11 @@ impl GroupBuilder {
 
         // Add required capabilities extension
         let rc_extension = RequiredCapabilitiesExtension::new(
-            &[APQMLS_EXTENSION_TYPE, ExtensionType::RequiredCapabilities],
-            &[],
+            &[
+                ExtensionType::RequiredCapabilities,
+                ExtensionType::AppDataDictionary,
+            ],
+            &[ProposalType::AppDataUpdate],
             &[],
         )
         .pipe(Extension::RequiredCapabilities);
@@ -109,7 +113,7 @@ impl GroupBuilder {
         self.t_extensions.add_or_replace(rc_extension.clone())?;
         self.pq_extensions.add_or_replace(rc_extension)?;
 
-        let apq_mls_extension = ApqMlsInfo {
+        let info = ApqInfo {
             t_session_group_id: apq_group_id.t_group_id.clone(),
             pq_session_group_id: apq_group_id.pq_group_id.clone(),
             mode: self.mode,
@@ -117,12 +121,14 @@ impl GroupBuilder {
             pq_cipher_suite: ciphersuite.pq_ciphersuite,
             t_epoch: GroupEpoch::from(0),
             pq_epoch: GroupEpoch::from(0),
-        }
-        .to_extension()?;
-
-        self.t_extensions
-            .add_or_replace(apq_mls_extension.clone())?;
-        self.pq_extensions.add_or_replace(apq_mls_extension)?;
+        };
+        let mut dictionary = AppDataDictionary::new().pipe(ensure_component_support)?;
+        let (component_id, data) = info.to_component_data()?.into_parts();
+        dictionary.insert(component_id, data.into());
+        let add_extension =
+            Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+        self.t_extensions.add_or_replace(add_extension.clone())?;
+        self.pq_extensions.add_or_replace(add_extension)?;
 
         let t_group = self
             .t_group_builder

--- a/src/key_package.rs
+++ b/src/key_package.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use crate::{
     ApqCiphersuite,
     authentication::{ApqCredentialWithKey, ApqSigner},
-    extension::ensure_extension_support,
+    extension::{ensure_extension_support, ensure_leaf_node_component_support},
     messages::{ApqKeyPackage, ApqKeyPackageIn},
 };
 
@@ -37,6 +37,8 @@ pub struct ApqKeyPackageBuilder {
     capabilities: Capabilities,
     t_kp_builder: KeyPackageBuilder,
     pq_kp_builder: KeyPackageBuilder,
+    key_package_extensions: Extensions<KeyPackage>,
+    leaf_node_extensions: Extensions<LeafNode>,
 }
 
 /// A bundle consisting of an [`ApqKeyPackage`] and its corresponding
@@ -69,6 +71,8 @@ impl ApqKeyPackageBuilder {
             capabilities: Capabilities::default(),
             t_kp_builder: KeyPackageBuilder::new(),
             pq_kp_builder: KeyPackageBuilder::new(),
+            key_package_extensions: Extensions::default(),
+            leaf_node_extensions: Extensions::default(),
         }
     }
 
@@ -81,8 +85,7 @@ impl ApqKeyPackageBuilder {
 
     /// Set the key package extensions.
     pub fn key_package_extensions(mut self, extensions: Extensions<KeyPackage>) -> Self {
-        self.t_kp_builder = self.t_kp_builder.key_package_extensions(extensions.clone());
-        self.pq_kp_builder = self.pq_kp_builder.key_package_extensions(extensions);
+        self.key_package_extensions = extensions;
         self
     }
 
@@ -103,8 +106,7 @@ impl ApqKeyPackageBuilder {
 
     /// Set the leaf node extensions.
     pub fn leaf_node_extensions(mut self, extensions: Extensions<LeafNode>) -> Self {
-        self.t_kp_builder = self.t_kp_builder.leaf_node_extensions(extensions.clone());
-        self.pq_kp_builder = self.pq_kp_builder.leaf_node_extensions(extensions);
+        self.leaf_node_extensions = extensions;
         self
     }
 
@@ -121,10 +123,21 @@ impl ApqKeyPackageBuilder {
             .pipe(ensure_extension_support)?
             .pipe(|c| ensure_ciphersuite_support(c, ciphersuite))?;
 
+        let ln_extensions = self
+            .leaf_node_extensions
+            .pipe(ensure_leaf_node_component_support)?;
+        let pk_extensions = self.key_package_extensions;
+
         self.t_kp_builder = self
             .t_kp_builder
-            .leaf_node_capabilities(capabilities.clone());
-        self.pq_kp_builder = self.pq_kp_builder.leaf_node_capabilities(capabilities);
+            .leaf_node_capabilities(capabilities.clone())
+            .leaf_node_extensions(ln_extensions.clone())
+            .key_package_extensions(pk_extensions.clone());
+        self.pq_kp_builder = self
+            .pq_kp_builder
+            .leaf_node_capabilities(capabilities)
+            .leaf_node_extensions(ln_extensions)
+            .key_package_extensions(pk_extensions);
         let t_kp_bundle = self.t_kp_builder.build(
             ciphersuite.t_ciphersuite,
             provider,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod merging;
 pub mod messages;
 pub mod processing;
 mod psk;
+mod secret;
 pub mod welcome;
 
 /// The combined ciphersuite of a [`ApqMlsGroup`].

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -5,23 +5,24 @@
 use std::fmt::Debug;
 
 use openmls::{
-    group::{ProcessMessageError, StagedCommit},
+    component::ComponentData,
+    group::{AppDataUpdates, MlsGroup, ProcessMessageError, StagedCommit},
     prelude::{
-        Credential, LeafNodeIndex, ProcessedMessage, ProcessedMessageContent, Proposal,
-        ProposalType, Sender,
+        AppDataUpdateOperation, Credential, LeafNodeIndex, ProcessedMessage,
+        ProcessedMessageContent, Proposal, ProposalIn, ProposalOrRefIn, ProposalType, Sender,
+        UnverifiedMessage,
     },
-    schedule::{ExternalPsk, PreSharedKeyId, Psk},
+    schedule::{PreSharedKeyId, Psk, psk::ApplicationPsk},
     storage::OpenMlsProvider,
 };
-use tap::Pipe as _;
 use thiserror::Error;
-use tls_codec::Serialize;
 
 use crate::{
     ApqMlsGroup,
-    extension::{APQMLS_EXTENSION_ID, ApqMlsInfo},
+    extension::{APQMLS_COMPONENT_ID, ApqInfo},
     messages::ApqProtocolMessage,
-    psk::{ApqPskError, ApqPskId, store_psk},
+    psk::{ApqPskError, store_psk},
+    secret::Secret,
 };
 
 /// A bundle consisting of the processed messages of both the traditional and
@@ -66,10 +67,10 @@ pub enum ApqProcessMessageError<StorageError> {
     InvalidMessageType,
     #[error("The MLS messages don't match.")]
     MismatchedMessages,
-    #[error("APQMLSInfo extension is missing or invalid in commit message.")]
-    MissingApqMlsInfo,
-    #[error("APQMLSInfo extension content is invalid.")]
-    InvalidApqMlsInfo,
+    #[error("APQInfo extension is missing or invalid in commit message.")]
+    MissingApqInfo,
+    #[error("APQInfo extension content is invalid.")]
+    InvalidApqInfo,
 }
 
 #[derive(Eq)]
@@ -277,9 +278,17 @@ impl ApqMlsGroup {
     {
         let protocol_message: ApqProtocolMessage = message.into();
         // We only export a PSK if we process a PQ message
+        let unverified_pq_message = self
+            .pq_group
+            .unprotect_message(provider, protocol_message.pq_protocol_message)?;
+        let pq_updates = extract_app_data_updates(&self.pq_group, &unverified_pq_message);
         let mut pq_message = self
             .pq_group
-            .process_message(provider, protocol_message.pq_protocol_message)?;
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_pq_message,
+                pq_updates,
+            )?;
 
         let msg_type = MessageType::new(pq_message.content(), &sender_equivalence)
             .ok_or(ApqProcessMessageError::InvalidMessageType)?;
@@ -293,27 +302,39 @@ impl ApqMlsGroup {
             pq_message.content(),
             ProcessedMessageContent::StagedCommitMessage(_)
         ) {
-            let psk_value = pq_message
-                .safe_export_secret(provider.crypto(), APQMLS_EXTENSION_ID)
-                .map_err(ApqPskError::ExportFromProcessed)?;
+            let apq_exporter: Secret = pq_message
+                .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
+                .map_err(ApqPskError::ExportFromProcessed)?
+                .into();
 
-            let next_epoch = self.pq_group.epoch().as_u64() + 1;
-            ApqPskId {
-                group_id: self.pq_group.group_id().clone(),
-                epoch: next_epoch,
-            }
-            .tls_serialize_detached()
-            .map_err(ApqPskError::SerializingPskId)?
-            .pipe(ExternalPsk::new)
-            .pipe(Psk::External)
-            .pipe(|psk| PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk))
-            .map_err(ApqPskError::DerivingPskId)?
-            .pipe(|id| store_psk(provider, id, &psk_value))?;
+            let apq_psk_id = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
+                .map_err(ApqPskError::DerivingPskId)?;
+            let apq_psk = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
+                .map_err(ApqPskError::DerivingPskId)?;
+            drop(apq_exporter); // Zeroize the secret
+
+            let psk = Psk::Application(ApplicationPsk::new(
+                APQMLS_COMPONENT_ID,
+                apq_psk_id.as_slice().into(),
+            ));
+            let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
+                .map_err(ApqPskError::DerivingPskId)?;
+            store_psk(provider, id, apq_psk.as_slice())?;
         }
 
+        let unverified_t_message = self
+            .t_group
+            .unprotect_message(provider, protocol_message.t_protocol_message)?;
+        let t_updates = extract_app_data_updates(&self.t_group, &unverified_t_message);
         let t_message = self
             .t_group
-            .process_message(provider, protocol_message.t_protocol_message)?;
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_t_message,
+                t_updates,
+            )?;
 
         let msg_type = MessageType::new(t_message.content(), &sender_equivalence)
             .ok_or(ApqProcessMessageError::InvalidMessageType)?;
@@ -327,53 +348,52 @@ impl ApqMlsGroup {
             return Err(ApqProcessMessageError::MismatchedMessages);
         }
 
-        // If both are commits, the APQMLSInfo extension must be updated and in
+        // If both are commits, the [`ApqInfo`] component must be updated and in
         // line with the info of both groups
         if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
             && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) =
                 t_message.content()
         {
-            let pq_extension =
-                ApqMlsInfo::from_extensions(pq_staged_commit.group_context().extensions())
-                    .map_err(|_| ApqProcessMessageError::MissingApqMlsInfo)?
-                    .ok_or(ApqProcessMessageError::MissingApqMlsInfo)?;
-            let t_extension =
-                ApqMlsInfo::from_extensions(t_staged_commit.group_context().extensions())
-                    .map_err(|_| ApqProcessMessageError::MissingApqMlsInfo)?
-                    .ok_or(ApqProcessMessageError::MissingApqMlsInfo)?;
+            let pq_apq_info =
+                ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
+                    .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
+                    .ok_or(ApqProcessMessageError::MissingApqInfo)?;
+            let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
+                .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
+                .ok_or(ApqProcessMessageError::MissingApqInfo)?;
 
-            // Extension contents must match
-            let extensions_match = pq_extension == t_extension;
+            // ApqInfo contents must match
+            let apq_info_match = pq_apq_info == t_apq_info;
 
             // Epochs must be in line with the groups
-            let epochs_match = pq_extension.pq_epoch == pq_staged_commit.group_context().epoch()
-                && t_extension.t_epoch == t_staged_commit.group_context().epoch();
+            let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
+                && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
 
             // New epochs must be one higher than the current ones
-            let epochs_are_incremented = pq_extension.pq_epoch.as_u64()
+            let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64()
                 == self.pq_group.epoch().as_u64() + 1
-                && t_extension.t_epoch.as_u64() == self.t_group.epoch().as_u64() + 1;
+                && t_apq_info.t_epoch.as_u64() == self.t_group.epoch().as_u64() + 1;
 
             // Group IDs must be in line with the groups
-            let group_ids_match = pq_extension.pq_session_group_id == *self.pq_group.group_id()
-                && t_extension.t_session_group_id == *self.t_group.group_id();
+            let group_ids_match = pq_apq_info.pq_session_group_id == *self.pq_group.group_id()
+                && t_apq_info.t_session_group_id == *self.t_group.group_id();
 
             // Ciphersuites must be in line with the groups
-            let ciphersuites_match = pq_extension.pq_cipher_suite == self.pq_group.ciphersuite()
-                && t_extension.t_cipher_suite == self.t_group.ciphersuite();
+            let ciphersuites_match = pq_apq_info.pq_cipher_suite == self.pq_group.ciphersuite()
+                && t_apq_info.t_cipher_suite == self.t_group.ciphersuite();
 
             // Mode is correctly set
             let ciphersuite_matches_mode =
-                self.ciphersuite() == pq_extension.mode.default_ciphersuite();
+                self.ciphersuite() == pq_apq_info.mode.default_ciphersuite();
 
-            if !extensions_match
+            if !apq_info_match
                 || !epochs_match
                 || !epochs_are_incremented
                 || !group_ids_match
                 || !ciphersuites_match
                 || !ciphersuite_matches_mode
             {
-                return Err(ApqProcessMessageError::InvalidApqMlsInfo);
+                return Err(ApqProcessMessageError::InvalidApqInfo);
             }
         }
 
@@ -382,4 +402,28 @@ impl ApqMlsGroup {
             pq_message,
         })
     }
+}
+
+fn extract_app_data_updates(
+    group: &MlsGroup,
+    unverified: &UnverifiedMessage,
+) -> Option<AppDataUpdates> {
+    let mut updater = group.app_data_dictionary_updater();
+    let mut updated = false;
+    for proposal in unverified.committed_proposals()? {
+        if let ProposalOrRefIn::Proposal(p) = proposal
+            && let ProposalIn::AppDataUpdate(p) = &**p
+        {
+            match p.operation() {
+                AppDataUpdateOperation::Update(data) => {
+                    updater.set(ComponentData::from_parts(p.component_id(), data.clone()));
+                }
+                AppDataUpdateOperation::Remove => {
+                    updater.remove(&p.component_id());
+                }
+            }
+            updated = true;
+        }
+    }
+    updated.then(|| updater.changes()).flatten()
 }

--- a/src/psk.rs
+++ b/src/psk.rs
@@ -7,19 +7,17 @@
 
 use openmls::{
     group::{
-        GroupId, MlsGroup, PendingSafeExportSecretError, ProcessedMessageSafeExportSecretError,
+        MlsGroup, PendingSafeExportSecretError, ProcessedMessageSafeExportSecretError,
         SafeExportSecretError,
     },
     prelude::{Ciphersuite, CryptoError},
-    schedule::{ExternalPsk, PreSharedKeyId, Psk, errors::PskError},
+    schedule::{PreSharedKeyId, Psk, errors::PskError, psk::ApplicationPsk},
     storage::OpenMlsProvider,
 };
 use openmls_traits::storage::StorageProvider as _;
-use tap::Pipe as _;
 use thiserror::Error;
-use tls_codec::{Serialize as _, TlsSerialize, TlsSize};
 
-use crate::extension::APQMLS_EXTENSION_ID;
+use crate::{extension::APQMLS_COMPONENT_ID, secret::Secret};
 
 /// Error while handling PSKs in APQMLS.
 #[derive(Debug, Error)]
@@ -38,14 +36,7 @@ pub enum ApqPskError<StorageError> {
     SerializingPskId(#[from] tls_codec::Error),
 }
 
-/// The ID of a PSK in APQMLS, consisting of the group ID and epoch of the PQ
-/// group.
-#[derive(Debug, Clone, TlsSize, TlsSerialize)]
-pub(crate) struct ApqPskId {
-    pub(crate) group_id: GroupId,
-    pub(crate) epoch: u64,
-}
-
+/// <https://datatracker.ietf.org/doc/html/draft-ietf-mls-combiner#name-key-schedule>
 pub(crate) fn derive_and_store_psk<
     Provider: openmls::storage::OpenMlsProvider,
     const FROM_PENDING: bool,
@@ -53,31 +44,32 @@ pub(crate) fn derive_and_store_psk<
     provider: &Provider,
     group: &mut MlsGroup,
     t_ciphersuite: Ciphersuite,
-    //ciphersuite: Ciphersuite,
 ) -> Result<PreSharedKeyId, ApqPskError<Provider::StorageError>> {
-    let (psk_value, epoch) = if FROM_PENDING {
-        let psk_value = group.safe_export_secret_from_pending(
-            provider.crypto(),
-            provider.storage(),
-            APQMLS_EXTENSION_ID,
-        )?;
-        let epoch = group.epoch().as_u64() + 1;
-        (psk_value, epoch)
+    let apq_exporter: Secret = if FROM_PENDING {
+        group
+            .safe_export_secret_from_pending(
+                provider.crypto(),
+                provider.storage(),
+                APQMLS_COMPONENT_ID,
+            )?
+            .into()
     } else {
-        let psk_value =
-            group.safe_export_secret(provider.crypto(), provider.storage(), APQMLS_EXTENSION_ID)?;
-        (psk_value, group.epoch().as_u64())
+        group
+            .safe_export_secret(provider.crypto(), provider.storage(), APQMLS_COMPONENT_ID)?
+            .into()
     };
-    // Prepare the PSK for the T group.
-    ApqPskId {
-        group_id: group.group_id().clone(),
-        epoch,
-    }
-    .tls_serialize_detached()?
-    .pipe(ExternalPsk::new)
-    .pipe(Psk::External)
-    .pipe(|psk| PreSharedKeyId::new(t_ciphersuite, provider.rand(), psk))?
-    .pipe(|id| store_psk(provider, id, &psk_value))
+
+    let apq_psk_id = apq_exporter.derive_secret(provider.crypto(), t_ciphersuite, "psk_id")?;
+    let apq_psk = apq_exporter.derive_secret(provider.crypto(), t_ciphersuite, "psk")?;
+    drop(apq_exporter); // Zeroize the secret
+
+    let psk = Psk::Application(ApplicationPsk::new(
+        APQMLS_COMPONENT_ID,
+        apq_psk_id.as_slice().into(),
+    ));
+
+    let id = PreSharedKeyId::new(t_ciphersuite, provider.rand(), psk)?;
+    store_psk(provider, id, apq_psk.as_slice())
 }
 
 pub(crate) fn store_psk<Provider: OpenMlsProvider>(

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Taken verbatim from
+//! <https://github.com/openmls/openmls/blob/f0b97fc1df949a193630d40baa6ea41f0161742c/openmls/src/ciphersuite/secret.rs>
+
+use openmls::prelude::{Ciphersuite, CryptoError, OpenMlsCrypto};
+use tls_codec::{SecretVLBytes, Serialize, TlsSerialize, TlsSize};
+
+#[derive(TlsSerialize, TlsSize)]
+pub(crate) struct Secret {
+    value: SecretVLBytes,
+}
+
+impl From<Vec<u8>> for Secret {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
+impl Secret {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.value.as_slice()
+    }
+
+    /// HKDF expand where `self` is `prk`.
+    pub(crate) fn hkdf_expand(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        info: &[u8],
+        okm_len: usize,
+    ) -> Result<Self, CryptoError> {
+        let key = crypto
+            .hkdf_expand(
+                ciphersuite.hash_algorithm(),
+                self.value.as_slice(),
+                info,
+                okm_len,
+            )
+            .map_err(|_| CryptoError::CryptoLibraryError)?;
+        if key.as_slice().is_empty() {
+            return Err(CryptoError::InvalidLength);
+        }
+        Ok(Self { value: key })
+    }
+
+    /// Expand a `Secret` to a new `Secret` of length `length` including a
+    /// `label` and a `context`.
+    pub(crate) fn kdf_expand_label(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        label: &str,
+        context: &[u8],
+        length: usize,
+    ) -> Result<Secret, CryptoError> {
+        let full_label = format!("MLS 1.0 {label}");
+        let info = KdfLabel {
+            length: length
+                .try_into()
+                .map_err(|_| CryptoError::KdfLabelTooLarge)?,
+            label: full_label.as_bytes(),
+            context,
+        }
+        .tls_serialize_detached()
+        .map_err(|_| CryptoError::KdfSerializationError)?;
+        self.hkdf_expand(crypto, ciphersuite, &info, length)
+    }
+
+    /// Derive a new `Secret` from the this one by expanding it with the given
+    /// `label` and an empty `context`.
+    pub(crate) fn derive_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        label: &str,
+    ) -> Result<Secret, CryptoError> {
+        self.kdf_expand_label(crypto, ciphersuite, label, &[], ciphersuite.hash_length())
+    }
+}
+
+/// `KdfLabel` is later serialized and used in the `label` field of
+/// `kdf_expand_label`.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
+///     uint16 length = Length;
+///     opaque label<V> = "MLS 1.0 " + Label;
+///     opaque context<V> = Context;
+/// } KDFLabel;
+/// ```
+#[derive(TlsSerialize, TlsSize)]
+struct KdfLabel<'a> {
+    length: u16,
+    label: &'a [u8],
+    context: &'a [u8],
+}


### PR DESCRIPTION
Replace the previous Unknown extension approach with the
`app_data_dictionary` component mechanism from
`draft-ietf-mls-extensions-09` and `draft-ietf-mls-combiner-02`.

- Store `APQInfo` as a component keyed by `APQMLS_COMPONENT_ID` (0x8001) in
  the app_data_dictionary `GroupContext` extension
- Replace `GroupContextExtensions` proposals with `AppDataUpdate` proposals
  for epoch transitions in both PQ and T commits
- Update PSK derivation to two-step KDF: SafeExportSecret ->
  DeriveSecret("psk_id") + DeriveSecret("psk"), using
  PSKType::Application with component_id
- Advertise required/supported components via `app_components`
  (ComponentID 0x0001) in leaf node and group context extensions