### PR TITLE
feat: expose free functions and builders for working without ApqMlsGroup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,10 +796,10 @@ dependencies = [
 [[package]]
 name = "hpke-rs"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#07741e11f74789064eb00802bf449faeaad7b233"
+source = "git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d639669d9669c73#42f9b421d499dec01dcb3fd80d639669d9669c73"
 dependencies = [
  "hpke-rs-crypto",
- "hpke-rs-libcrux 0.6.1 (git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384)",
+ "hpke-rs-libcrux 0.6.1 (git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d639669d9669c73)",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#07741e11f74789064eb00802bf449faeaad7b233"
+source = "git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d639669d9669c73#42f9b421d499dec01dcb3fd80d639669d9669c73"
 dependencies = [
  "rand_core 0.9.5",
  "zeroize",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-libcrux"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#07741e11f74789064eb00802bf449faeaad7b233"
+source = "git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d639669d9669c73#42f9b421d499dec01dcb3fd80d639669d9669c73"
 dependencies = [
  "hpke-rs-crypto",
  "libcrux-aead",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.6.1"
-source = "git+https://github.com/boxdot/hpke-rs?branch=dima%2Fp384#07741e11f74789064eb00802bf449faeaad7b233"
+source = "git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d639669d9669c73#42f9b421d499dec01dcb3fd80d639669d9669c73"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "log",
  "openmls_basic_credential",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "hex",
  "log",
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "log",
  "openmls_traits",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#92dffe36ba092a03abbd20f91c9229bb5de3fd01"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +128,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +175,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array 0.4.11",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -144,6 +183,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -248,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-models"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +387,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "hybrid-array 0.4.11",
+ "getrandom 0.4.2",
+ "hybrid-array",
  "rand_core 0.10.1",
 ]
 
@@ -405,8 +457,18 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -427,7 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -439,7 +501,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -459,12 +523,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -473,8 +537,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -487,7 +551,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -510,9 +574,9 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -593,10 +657,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -605,6 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -667,6 +749,18 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -781,7 +875,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -791,6 +894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -861,7 +973,7 @@ source = "git+https://github.com/cryspen/hpke-rs?rev=42f9b421d499dec01dcb3fd80d6
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "hkdf",
+ "hkdf 0.12.4",
  "hpke-rs-crypto",
  "k256",
  "ml-kem",
@@ -871,20 +983,11 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "x-wing",
  "x25519-dalek 2.0.1",
  "zeroize",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -1041,6 +1144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,15 +1178,6 @@ checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1344,6 +1447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,18 +1482,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "ml-dsa"
-version = "0.0.4"
+name = "minicov"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
- "const-oid",
- "hybrid-array 0.3.1",
- "num-traits",
- "pkcs8",
- "rand_core 0.6.4",
- "sha3 0.10.9",
- "signature",
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1393,21 +1522,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c77d5ff6d755d09a0ef4d4d28c2b7e83658fe83e8c736d55e93d43e380d1cd"
 dependencies = [
- "hybrid-array 0.4.11",
+ "hybrid-array",
  "kem",
  "module-lattice",
  "rand_core 0.10.1",
- "sha3 0.11.0",
+ "sha3",
 ]
 
 [[package]]
 name = "module-lattice"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
  "ctutils",
- "hybrid-array 0.4.11",
+ "hybrid-array",
  "num-traits",
 ]
 
@@ -1452,6 +1581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1459,6 +1598,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -1469,27 +1614,34 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
+ "backtrace",
+ "itertools",
  "log",
+ "once_cell",
  "openmls_basic_credential",
  "openmls_libcrux_crypto",
  "openmls_memory_storage",
  "openmls_rust_crypto",
  "openmls_sqlite_storage",
+ "openmls_test",
  "openmls_traits",
+ "rand 0.9.4",
  "rayon",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror",
  "tls_codec",
+ "wasm-bindgen-test",
  "zeroize",
 ]
 
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -1505,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -1526,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "hex",
  "log",
@@ -1539,13 +1691,13 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "ed25519-dalek",
- "hkdf",
- "hmac",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
@@ -1555,9 +1707,10 @@ dependencies = [
  "p256",
  "p384",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tls_codec",
 ]
@@ -1565,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "log",
  "openmls_traits",
@@ -1576,9 +1729,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "openmls_test"
+version = "0.2.1"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+dependencies = [
+ "ansi_term",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "proc-macro2",
+ "quote",
+ "rstest",
+ "rstest_reuse",
+ "syn",
+]
+
+[[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#b28168109ca409b91f2e289c0dda4a33d2951a79"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#ac45b95dde09c024bbf3876e4b71d754bf49368c"
 dependencies = [
  "serde",
  "tls_codec",
@@ -1593,7 +1761,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1605,7 +1773,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1641,8 +1809,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -1721,6 +1899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1954,13 +2141,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
+dependencies = [
+ "quote",
+ "rand 0.8.6",
+ "syn",
 ]
 
 [[package]]
@@ -1976,6 +2209,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -2008,9 +2247,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2095,13 +2334,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.9"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2111,7 +2351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -2140,6 +2391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,8 +2425,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2307,8 +2584,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2321,6 +2598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,9 +2615,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2532,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2879,45 @@ checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
 
 [[package]]
 name = "wasm-encoder"
@@ -2608,6 +2964,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2987,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2636,6 +3014,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -2749,7 +3136,7 @@ dependencies = [
  "kem",
  "ml-kem",
  "rand_core 0.10.1",
- "sha3 0.11.0",
+ "sha3",
  "x25519-dalek 3.0.0-pre.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,6 @@ openmls_basic_credential = { git = "https://github.com/boxdot/openmls", branch =
 
 # feat: add p384 support
 # <https://github.com/cryspen/hpke-rs/pull/150>
-hpke-rs = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
-hpke-rs-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
-hpke-rs-rust-crypto = { git = "https://github.com/boxdot/hpke-rs", branch = "dima/p384" }
-# hpke-rs = { path = "../hpke-rs" }
-# hpke-rs-crypto = { path = "../hpke-rs/traits/" }
-# hpke-rs-rust-crypto = { path = "../hpke-rs/rust_crypto_provider/" }
+hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "42f9b421d499dec01dcb3fd80d639669d9669c73" }
+hpke-rs-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "42f9b421d499dec01dcb3fd80d639669d9669c73" }
+hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "42f9b421d499dec01dcb3fd80d639669d9669c73" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ thiserror = "2.0.12"
 tls_codec = "0.4.2"
 
 [dev-dependencies]
+# `test-utils` exposes `MlsGroup::export_group_context` for the group context tests
+openmls = { version = "0.8.1", features = ["test-utils"] }
 openmls_rust_crypto = { version = "0.5.1", features = [
     "draft-ietf-mls-pq-ciphersuites",
 ] }

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -8,7 +8,10 @@ use openmls::prelude::{
     BasicCredential, CredentialWithKey, CryptoError, SignaturePublicKey, SignatureScheme,
 };
 use openmls_basic_credential::SignatureKeyPair;
-use openmls_traits::storage::{self, CURRENT_VERSION};
+use openmls_traits::{
+    signatures::Signer,
+    storage::{self, CURRENT_VERSION},
+};
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 use tls_codec::{Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
@@ -57,22 +60,11 @@ impl ApqCredentialWithKey {
 
 /// A trait for types that can sign messages in APQMLS.
 pub trait ApqSigner {
-    fn t_signer(&self) -> &SignatureKeyPair;
-    fn pq_signer(&self) -> &SignatureKeyPair;
+    type TSigner: Signer;
+    type PqSigner: Signer;
 
-    fn t_verifying_key(&self) -> &[u8] {
-        self.t_signer().public()
-    }
-    fn pq_verifying_key(&self) -> &[u8] {
-        self.pq_signer().public()
-    }
-
-    fn verifying_key(&self) -> ApqVerifyingKey {
-        ApqVerifyingKey {
-            t_verifying_key: self.t_verifying_key().into(),
-            pq_verifying_key: self.pq_verifying_key().into(),
-        }
-    }
+    fn t_signer(&self) -> &Self::TSigner;
+    fn pq_signer(&self) -> &Self::PqSigner;
 }
 
 /// The signature scheme of a [`ApqSigner`].
@@ -111,15 +103,18 @@ impl ApqSignatureKeyPair {
 
     pub fn id(&self) -> ApqStorageId {
         ApqStorageId {
-            t_signature_scheme: self.t_signer().signature_scheme(),
-            t_verifying_key: self.t_verifying_key().to_vec(),
-            pq_signature_scheme: self.pq_signer().signature_scheme(),
-            pq_verifying_key: self.pq_verifying_key().to_vec(),
+            t_signature_scheme: self.t_signer.signature_scheme(),
+            t_verifying_key: self.t_signer.public().to_vec(),
+            pq_signature_scheme: self.pq_signer.signature_scheme(),
+            pq_verifying_key: self.pq_signer.public().to_vec(),
         }
     }
 }
 
 impl ApqSigner for ApqSignatureKeyPair {
+    type TSigner = SignatureKeyPair;
+    type PqSigner = SignatureKeyPair;
+
     fn t_signer(&self) -> &SignatureKeyPair {
         &self.t_signer
     }

--- a/src/commit_builder.rs
+++ b/src/commit_builder.rs
@@ -5,7 +5,8 @@
 use openmls::{
     group::{
         CommitBuilder as MlsGroupCommitBuilder, CommitBuilderStageError, CommitMessageBundle,
-        CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, QueuedProposal,
+        CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, MlsGroup,
+        QueuedProposal,
     },
     prelude::{
         AppDataUpdateProposal, InvalidExtensionError, LeafNodeIndex, LeafNodeParameters,
@@ -13,11 +14,12 @@ use openmls::{
     },
     storage::OpenMlsProvider,
 };
+use serde::{Deserialize, Serialize};
 use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    ApqMlsGroup,
+    ApqMlsGroup, ApqMlsGroupMut,
     authentication::ApqSigner,
     extension::APQMLS_COMPONENT_ID,
     messages::{ApqGroupInfo, ApqKeyPackage, ApqMlsMessageOut, ApqWelcome},
@@ -42,6 +44,7 @@ pub enum CreateCommitError<StorageError> {
 }
 
 /// A message bundle resulting from a commit operation in APQMLS.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApqCommitMessageBundle {
     pub commit: ApqMlsMessageOut,
     pub welcome: Option<ApqWelcome>,
@@ -109,6 +112,7 @@ struct ConfigValues {
     pq_leaf_node_parameters: Option<LeafNodeParameters>,
     proposed_adds: Vec<ApqKeyPackage>,
     proposed_removals: Vec<LeafNodeIndex>,
+    create_group_info: bool,
 }
 
 impl ConfigValues {
@@ -148,15 +152,20 @@ impl ConfigValues {
 /// A builder for creating commits in an APQMLS group. This builder can be used
 /// to affect membership changes and issue full updates.
 pub struct CommitBuilder<'a> {
-    group: &'a mut ApqMlsGroup,
+    group: ApqMlsGroupMut<'a>,
     values: ConfigValues,
 }
 
 impl<'a> CommitBuilder<'a> {
-    /// returns a new [`CommitBuilder`] for the given [`openmls::group::MlsGroup`].
+    /// Creates a new [`CommitBuilder`] for the given [`ApqMlsGroup`] group.
     pub fn new(group: &'a mut ApqMlsGroup) -> Self {
+        Self::from_groups(&mut group.t_group, &mut group.pq_group)
+    }
+
+    /// Creates a new [`CommitBuilder`] from the given mutable [`openmls::group::MlsGroup`]s.
+    pub fn from_groups(t_group: &'a mut MlsGroup, pq_group: &'a mut MlsGroup) -> Self {
         Self {
-            group,
+            group: ApqMlsGroupMut::from_groups(t_group, pq_group),
             values: ConfigValues::default(),
         }
     }
@@ -229,6 +238,12 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Sets whether or not a [`GroupInfo`] should be created when the commit is staged.
+    pub fn create_group_info(mut self, create_group_info: bool) -> Self {
+        self.values.create_group_info = create_group_info;
+        self
+    }
+
     /// Perform all steps to finish the builder.
     /// - load the PSKs for the PskProposals marked for inclusion
     /// - build the commit
@@ -266,7 +281,8 @@ impl<'a> CommitBuilder<'a> {
             .add_proposal(Proposal::AppDataUpdate(Box::new(
                 app_data_update_proposal.clone(),
             )))
-            .load_psks(provider.storage())?;
+            .load_psks(provider.storage())?
+            .create_group_info(self.values.create_group_info);
         let mut updater = pq_builder.app_data_dictionary_updater();
         updater.set(apq_info_component_data.clone());
         let changes = updater.changes();
@@ -278,7 +294,7 @@ impl<'a> CommitBuilder<'a> {
         // Prepare the PSK for the T group.
         let psk_proposal = derive_and_store_psk::<_, true>(
             provider,
-            &mut self.group.pq_group,
+            self.group.pq_group,
             self.group.t_group.ciphersuite(),
         )?
         .pipe(PreSharedKeyProposal::new)
@@ -292,7 +308,8 @@ impl<'a> CommitBuilder<'a> {
             .pipe(|b| self.values.apply::<true>(b))
             .add_proposal(psk_proposal)
             .add_proposal(Proposal::AppDataUpdate(Box::new(app_data_update_proposal)))
-            .load_psks(provider.storage())?;
+            .load_psks(provider.storage())?
+            .create_group_info(self.values.create_group_info);
         let mut updater = t_builder.app_data_dictionary_updater();
         updater.set(apq_info_component_data);
         let changes = updater.changes();

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -13,7 +13,7 @@ use openmls::{
 use tap::Pipe;
 use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup};
+use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup, ApqMlsGroupMut};
 
 /// The component ID of the APQMLS component.
 ///
@@ -161,6 +161,13 @@ pub(super) fn ensure_leaf_node_component_support(
 }
 
 impl ApqMlsGroup {
+    /// Get the APQMLS component from the group, if it exists.
+    pub fn apq_info(&self) -> Option<ApqInfo> {
+        ApqInfo::from_extensions(self.t_group.extensions()).ok()?
+    }
+}
+
+impl ApqMlsGroupMut<'_> {
     /// Get the APQMLS component from the group, if it exists.
     pub fn apq_info(&self) -> Option<ApqInfo> {
         ApqInfo::from_extensions(self.t_group.extensions()).ok()?

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -125,38 +125,33 @@ pub(super) fn ensure_extension_support(
 pub(super) fn ensure_component_support(
     mut dictionary: AppDataDictionary,
 ) -> Result<AppDataDictionary, tls_codec::Error> {
-    dictionary.insert(
-        ComponentId::from(ComponentType::AppComponents),
-        [APQMLS_COMPONENT_ID].as_slice().tls_serialize_detached()?,
-    );
-    Ok(dictionary)
-}
-
-pub(super) fn ensure_leaf_node_component_support(
-    mut extensions: Extensions<LeafNode>,
-) -> Result<Extensions<LeafNode>, tls_codec::Error> {
-    let mut dictionary = extensions
-        .app_data_dictionary()
-        .map(|extension| extension.dictionary().clone())
-        .unwrap_or_default();
     let mut app_components: Vec<ComponentId> = dictionary
         .get(&ComponentId::from(ComponentType::AppComponents))
         .map(Vec::tls_deserialize_exact)
         .transpose()?
         .unwrap_or_default();
-
     if !app_components.contains(&APQMLS_COMPONENT_ID) {
         app_components.push(APQMLS_COMPONENT_ID);
         dictionary.insert(
             ComponentId::from(ComponentType::AppComponents),
             app_components.tls_serialize_detached()?,
         );
-        let extension = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
-        extensions
-            .add_or_replace(extension)
-            .expect("logic error: extension is valid");
     }
+    Ok(dictionary)
+}
 
+pub(super) fn ensure_leaf_node_component_support(
+    mut extensions: Extensions<LeafNode>,
+) -> Result<Extensions<LeafNode>, tls_codec::Error> {
+    let dictionary = extensions
+        .app_data_dictionary()
+        .map(|extension| extension.dictionary().clone())
+        .unwrap_or_default();
+    let dictionary = ensure_component_support(dictionary)?;
+    let extension = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+    extensions
+        .add_or_replace(extension)
+        .expect("logic error: extension is valid");
     Ok(extensions)
 }
 

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -108,18 +108,13 @@ impl GroupBuilder {
             .unwrap_or_else(|| ApqGroupId::random(provider.rand()));
 
         // Add required capabilities extension
-        let rc_extension = RequiredCapabilitiesExtension::new(
-            &[
-                ExtensionType::RequiredCapabilities,
-                ExtensionType::AppDataDictionary,
-            ],
-            &[ProposalType::AppDataUpdate],
-            &[],
-        )
-        .pipe(Extension::RequiredCapabilities);
+        let t_rc = merged_required_capabilities(self.t_extensions.required_capabilities())
+            .pipe(Extension::RequiredCapabilities);
+        let pq_rc = merged_required_capabilities(self.pq_extensions.required_capabilities())
+            .pipe(Extension::RequiredCapabilities);
 
-        self.t_extensions.add_or_replace(rc_extension.clone())?;
-        self.pq_extensions.add_or_replace(rc_extension)?;
+        self.t_extensions.add_or_replace(t_rc)?;
+        self.pq_extensions.add_or_replace(pq_rc)?;
 
         let info = ApqInfo {
             t_session_group_id: apq_group_id.t_group_id.clone(),
@@ -276,4 +271,33 @@ impl GroupBuilder {
         // We set the capabilities for both groups in `build`.
         self
     }
+}
+
+fn merged_required_capabilities(
+    existing: Option<&RequiredCapabilitiesExtension>,
+) -> RequiredCapabilitiesExtension {
+    let mut extension_types = vec![
+        ExtensionType::RequiredCapabilities,
+        ExtensionType::AppDataDictionary,
+    ];
+    let mut proposal_types = vec![ProposalType::AppDataUpdate];
+    let mut credential_types = vec![];
+    if let Some(rq) = existing {
+        for &et in rq.extension_types() {
+            if !extension_types.contains(&et) {
+                extension_types.push(et);
+            }
+        }
+        for &pt in rq.proposal_types() {
+            if !proposal_types.contains(&pt) {
+                proposal_types.push(pt);
+            }
+        }
+        for &ct in rq.credential_types() {
+            if !credential_types.contains(&ct) {
+                credential_types.push(ct);
+            }
+        }
+    }
+    RequiredCapabilitiesExtension::new(&extension_types, &proposal_types, &credential_types)
 }

--- a/src/group_builder.rs
+++ b/src/group_builder.rs
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
+    component::ComponentData,
     group::{
         GroupContext, GroupEpoch, GroupId, MlsGroupBuilder, NewGroupError as OpenMlsNewGroupError,
         WireFormatPolicy,
     },
     prelude::{
-        AppDataDictionary, AppDataDictionaryExtension, Capabilities, Extension, ExtensionType,
-        Extensions, InvalidExtensionError, LeafNode, Lifetime, ProposalType,
-        RequiredCapabilitiesExtension, SenderRatchetConfiguration,
+        AppDataDictionaryExtension, Capabilities, Extension, ExtensionType, Extensions,
+        InvalidExtensionError, LeafNode, Lifetime, ProposalType, RequiredCapabilitiesExtension,
+        SenderRatchetConfiguration,
     },
     storage::OpenMlsProvider,
     treesync::errors::LeafNodeValidationError,
@@ -125,13 +126,10 @@ impl GroupBuilder {
             t_epoch: GroupEpoch::from(0),
             pq_epoch: GroupEpoch::from(0),
         };
-        let mut dictionary = AppDataDictionary::new().pipe(ensure_component_support)?;
-        let (component_id, data) = info.to_component_data()?.into_parts();
-        dictionary.insert(component_id, data.into());
-        let add_extension =
-            Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
-        self.t_extensions.add_or_replace(add_extension.clone())?;
-        self.pq_extensions.add_or_replace(add_extension)?;
+
+        let info_component = info.to_component_data()?;
+        ensure_group_context_component_support(&mut self.t_extensions, info_component.clone())?;
+        ensure_group_context_component_support(&mut self.pq_extensions, info_component)?;
 
         let t_group = self
             .t_group_builder
@@ -271,6 +269,24 @@ impl GroupBuilder {
         // We set the capabilities for both groups in `build`.
         self
     }
+}
+
+fn ensure_group_context_component_support<StorageError>(
+    extensions: &mut Extensions<GroupContext>,
+    apq_info: ComponentData,
+) -> Result<(), NewGroupError<StorageError>> {
+    let dictionary = extensions
+        .app_data_dictionary()
+        .map(|extension| extension.dictionary().clone())
+        .unwrap_or_default()
+        .pipe(ensure_component_support)?;
+    let mut dictionary = dictionary;
+    let (compoent_id, data) = apq_info.into_parts();
+    dictionary.insert(compoent_id, data.into());
+    extensions.add_or_replace(Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    ))?;
+    Ok(())
 }
 
 fn merged_required_capabilities(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,14 @@ impl ApqGroupId {
             pq_group_id: GroupId::random(rng),
         }
     }
+
+    pub fn t_group_id(&self) -> &GroupId {
+        &self.t_group_id
+    }
+
+    pub fn pq_group_id(&self) -> &GroupId {
+        &self.pq_group_id
+    }
 }
 
 /// An APQMLS group, consisting of a traditional MLS group and a post-quantum MLS
@@ -97,7 +105,27 @@ pub struct ApqMlsGroup {
     pub t_group: MlsGroup,
 }
 
+pub(crate) struct ApqMlsGroupMut<'a> {
+    t_group: &'a mut MlsGroup,
+    pq_group: &'a mut MlsGroup,
+}
+
+impl<'a> ApqMlsGroupMut<'a> {
+    pub fn from_groups(t_group: &'a mut MlsGroup, pq_group: &'a mut MlsGroup) -> Self {
+        Self { t_group, pq_group }
+    }
+}
+
 impl ApqMlsGroup {
+    /// Create a new APQMLS group from the traditional and post-quantum MLS groups.
+    pub fn from_groups(t_group: MlsGroup, pq_group: MlsGroup) -> Self {
+        Self { t_group, pq_group }
+    }
+
+    pub fn into_groups(self) -> (MlsGroup, MlsGroup) {
+        (self.t_group, self.pq_group)
+    }
+
     /// Returns a reference to the post-quantum group.
     pub fn pq_group(&self) -> &MlsGroup {
         &self.pq_group

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod merging;
 pub mod messages;
 pub mod processing;
 mod psk;
+pub mod public_group;
 mod secret;
 pub mod welcome;
 
@@ -96,21 +97,23 @@ impl ApqGroupId {
     }
 }
 
-/// An APQMLS group, consisting of a traditional MLS group and a post-quantum MLS
-/// group. The two traditional group can be used independently, except for
-/// membership updates.
+/// An APQMLS group, consisting of a traditional MLS group and a post-quantum MLS group.
+///
+/// The two groups can be used independently, except for membership updates.
 #[derive(Debug)]
 pub struct ApqMlsGroup {
     pq_group: MlsGroup,
     pub t_group: MlsGroup,
 }
 
-pub(crate) struct ApqMlsGroupMut<'a> {
+/// Same as [`ApqMlsGroup`], but references MLS groups instead of owning them.
+pub struct ApqMlsGroupMut<'a> {
     t_group: &'a mut MlsGroup,
     pq_group: &'a mut MlsGroup,
 }
 
 impl<'a> ApqMlsGroupMut<'a> {
+    /// A non-owning version of [`ApqMlsGroupMut::from_groups`].
     pub fn from_groups(t_group: &'a mut MlsGroup, pq_group: &'a mut MlsGroup) -> Self {
         Self { t_group, pq_group }
     }
@@ -120,6 +123,10 @@ impl ApqMlsGroup {
     /// Create a new APQMLS group from the traditional and post-quantum MLS groups.
     pub fn from_groups(t_group: MlsGroup, pq_group: MlsGroup) -> Self {
         Self { t_group, pq_group }
+    }
+
+    pub fn as_mut(&mut self) -> ApqMlsGroupMut<'_> {
+        ApqMlsGroupMut::from_groups(&mut self.t_group, &mut self.pq_group)
     }
 
     pub fn into_groups(self) -> (MlsGroup, MlsGroup) {

--- a/src/merging.rs
+++ b/src/merging.rs
@@ -4,10 +4,10 @@
 
 use openmls::{
     group::{MergeCommitError, MergePendingCommitError},
-    storage::{OpenMlsProvider, StorageProvider},
+    storage::{OpenMlsProvider, PublicStorageProvider, StorageProvider},
 };
 
-use crate::{ApqMlsGroup, processing::ApqStagedCommit};
+use crate::{ApqMlsGroup, processing::ApqStagedCommit, public_group::ApqPublicGroupMut};
 
 impl ApqMlsGroup {
     /// Merges the pending [`openmls::group::StagedCommit`] of the traditional group, as well as
@@ -45,6 +45,24 @@ impl ApqMlsGroup {
     ) -> Result<(), Storage::Error> {
         self.t_group.clear_pending_commit(provider)?;
         self.pq_group.clear_pending_commit(provider)?;
+        Ok(())
+    }
+}
+
+impl ApqPublicGroupMut<'_> {
+    /// Merge a [`openmls::group::StagedCommit`] into the public group.
+    pub fn merge_staged_commit<Storage: PublicStorageProvider>(
+        &mut self,
+        storage: &Storage,
+        staged_commit: ApqStagedCommit,
+    ) -> Result<(), MergeCommitError<Storage::Error>> {
+        let ApqStagedCommit {
+            t_staged_commit,
+            pq_staged_commit,
+        } = staged_commit;
+        self.pq_public_group
+            .merge_commit(storage, pq_staged_commit)?;
+        self.t_public_group.merge_commit(storage, t_staged_commit)?;
         Ok(())
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,26 +5,36 @@
 use openmls::{
     group::GroupEpoch,
     prelude::{
-        Ciphersuite, Credential, KeyPackage, KeyPackageIn, MlsMessageBodyIn, MlsMessageIn,
-        MlsMessageOut, OpenMlsCrypto, OpenMlsSignaturePublicKey, ProtocolMessage, ProtocolVersion,
-        RatchetTreeIn, SignatureError, Verifiable as _, Welcome,
+        Ciphersuite, Credential, KeyPackage, KeyPackageIn, KeyPackageVerifyError, MlsMessageBodyIn,
+        MlsMessageIn, MlsMessageOut, OpenMlsCrypto, OpenMlsSignaturePublicKey, ProtocolMessage,
+        ProtocolVersion, RatchetTreeIn, SignatureError, Verifiable as _, Welcome,
         group_info::{GroupInfo, VerifiableGroupInfo},
     },
     treesync::RatchetTree,
 };
 use serde::{Deserialize, Serialize};
-use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Deserialize as _, Serialize as _, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 use crate::{ApqGroupId, authentication::ApqVerifyingKey, extension::PqtMode};
 
 /// An incoming message for processing by an [`crate::ApqMlsGroup`].
-#[derive(Debug, Clone, TlsDeserialize, TlsSize)]
+#[derive(Debug, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct ApqMlsMessageIn {
     pub(crate) t_message: MlsMessageIn,
     pub(crate) pq_message: MlsMessageIn,
 }
 
 impl ApqMlsMessageIn {
+    pub fn t_message(&self) -> &MlsMessageIn {
+        &self.t_message
+    }
+
+    pub fn pq_message(&self) -> &MlsMessageIn {
+        &self.pq_message
+    }
+
     pub fn into_welcome(self) -> Option<ApqWelcome> {
         let MlsMessageBodyIn::Welcome(t_welcome) = self.t_message.extract() else {
             return None;
@@ -90,6 +100,12 @@ pub struct ApqMlsMessageOut {
     pub(crate) pq_message: MlsMessageOut,
 }
 
+impl ApqMlsMessageOut {
+    pub fn split(self) -> (MlsMessageOut, MlsMessageOut) {
+        (self.t_message, self.pq_message)
+    }
+}
+
 impl TryFrom<ApqMlsMessageOut> for ApqMlsMessageIn {
     type Error = tls_codec::Error;
 
@@ -106,9 +122,27 @@ impl TryFrom<ApqMlsMessageOut> for ApqMlsMessageIn {
 }
 
 /// A welcome message for joining an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize)]
 pub struct ApqWelcome {
     pub(crate) t_welcome: Welcome,
     pub(crate) pq_welcome: Welcome,
+}
+
+impl ApqWelcome {
+    pub fn new(t_welcome: Welcome, pq_welcome: Welcome) -> Self {
+        Self {
+            t_welcome,
+            pq_welcome,
+        }
+    }
+
+    pub fn split(self) -> (Welcome, Welcome) {
+        let Self {
+            t_welcome,
+            pq_welcome,
+        } = self;
+        (t_welcome, pq_welcome)
+    }
 }
 
 impl From<ApqWelcome> for ApqMlsMessageOut {
@@ -142,14 +176,42 @@ pub struct ApqRatchetTreeIn {
     pub(crate) pq_ratchet_tree: RatchetTreeIn,
 }
 
+impl ApqRatchetTreeIn {
+    pub fn new(t_ratchet_tree: RatchetTreeIn, pq_ratchet_tree: RatchetTreeIn) -> Self {
+        Self {
+            t_ratchet_tree,
+            pq_ratchet_tree,
+        }
+    }
+
+    pub fn split(self) -> (RatchetTreeIn, RatchetTreeIn) {
+        (self.t_ratchet_tree, self.pq_ratchet_tree)
+    }
+}
+
 /// A key package to add members to an [`crate::ApqMlsGroup`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApqKeyPackage {
     pub(crate) t_key_package: KeyPackage,
     pub(crate) pq_key_package: KeyPackage,
 }
 
 impl ApqKeyPackage {
+    pub fn new(t_key_package: KeyPackage, pq_key_package: KeyPackage) -> Self {
+        Self {
+            t_key_package,
+            pq_key_package,
+        }
+    }
+
+    pub fn t_key_package(&self) -> &KeyPackage {
+        &self.t_key_package
+    }
+
+    pub fn pq_key_package(&self) -> &KeyPackage {
+        &self.pq_key_package
+    }
+
     pub fn mode(&self) -> PqtMode {
         match self.pq_key_package.ciphersuite() {
             Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
@@ -185,7 +247,24 @@ pub struct ApqKeyPackageIn {
     pub(crate) pq_key_package: KeyPackageIn,
 }
 
+impl ApqKeyPackageIn {
+    pub fn new(t_key_package: KeyPackageIn, pq_key_package: KeyPackageIn) -> Self {
+        Self {
+            t_key_package,
+            pq_key_package,
+        }
+    }
+
+    pub fn unwrap_verified(self) -> Result<ApqKeyPackage, KeyPackageVerifyError> {
+        Ok(ApqKeyPackage {
+            t_key_package: self.t_key_package.unwrap_verified()?,
+            pq_key_package: self.pq_key_package.unwrap_verified()?,
+        })
+    }
+}
+
 /// The group info of an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApqGroupInfo {
     pub(crate) t_group_info: GroupInfo,
     pub(crate) pq_group_info: GroupInfo,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -77,6 +77,13 @@ pub struct ApqProtocolMessage {
 }
 
 impl ApqProtocolMessage {
+    pub fn new(t_protocol_message: ProtocolMessage, pq_protocol_message: ProtocolMessage) -> Self {
+        Self {
+            t_protocol_message,
+            pq_protocol_message,
+        }
+    }
+
     pub fn group_id(&self) -> ApqGroupId {
         ApqGroupId {
             t_group_id: self.t_protocol_message.group_id().clone(),
@@ -268,6 +275,19 @@ impl ApqKeyPackageIn {
 pub struct ApqGroupInfo {
     pub(crate) t_group_info: GroupInfo,
     pub(crate) pq_group_info: GroupInfo,
+}
+
+impl ApqGroupInfo {
+    pub fn new(t_group_info: GroupInfo, pq_group_info: GroupInfo) -> Self {
+        Self {
+            t_group_info,
+            pq_group_info,
+        }
+    }
+
+    pub fn into_parts(self) -> (GroupInfo, GroupInfo) {
+        (self.t_group_info, self.pq_group_info)
+    }
 }
 
 impl From<ApqGroupInfo> for ApqMlsMessageOut {

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -6,7 +6,10 @@ use std::fmt::Debug;
 
 use openmls::{
     component::ComponentData,
-    group::{AppDataUpdates, MlsGroup, ProcessMessageError, StagedCommit},
+    group::{
+        AppDataUpdates, MlsGroup, ProcessMessageError, ProcessedMessageSafeExportSecretError,
+        StagedCommit, StagedSafeExportSecretError,
+    },
     prelude::{
         AppDataUpdateOperation, Credential, LeafNodeIndex, ProcessedMessage,
         ProcessedMessageContent, Proposal, ProposalIn, ProposalOrRefIn, ProposalType, Sender,
@@ -321,26 +324,36 @@ where
         pq_message.content(),
         ProcessedMessageContent::StagedCommitMessage(_)
     ) {
-        let apq_exporter: Secret = pq_message
-            .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
-            .map_err(ApqPskError::ExportFromProcessed)?
-            .into();
+        match pq_message.safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID) {
+            Ok(apq_exporter_bytes) => {
+                let apq_exporter: Secret = apq_exporter_bytes.into();
 
-        let apq_psk_id = apq_exporter
-            .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk_id")
-            .map_err(ApqPskError::DerivingPskId)?;
-        let apq_psk = apq_exporter
-            .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk")
-            .map_err(ApqPskError::DerivingPskId)?;
-        drop(apq_exporter); // Zeroize the secret
+                let apq_psk_id = apq_exporter
+                    .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk_id")
+                    .map_err(ApqPskError::DerivingPskId)?;
+                let apq_psk = apq_exporter
+                    .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk")
+                    .map_err(ApqPskError::DerivingPskId)?;
+                drop(apq_exporter); // Zeroize the secret
 
-        let psk = Psk::Application(ApplicationPsk::new(
-            APQMLS_COMPONENT_ID,
-            apq_psk_id.as_slice().into(),
-        ));
-        let id = PreSharedKeyId::new(t_group.ciphersuite(), provider.rand(), psk)
-            .map_err(ApqPskError::DerivingPskId)?;
-        store_psk(provider, id, apq_psk.as_slice())?;
+                let psk = Psk::Application(ApplicationPsk::new(
+                    APQMLS_COMPONENT_ID,
+                    apq_psk_id.as_slice().into(),
+                ));
+                let id = PreSharedKeyId::new(t_group.ciphersuite(), provider.rand(), psk)
+                    .map_err(ApqPskError::DerivingPskId)?;
+                store_psk(provider, id, apq_psk.as_slice())?;
+            }
+            Err(ProcessedMessageSafeExportSecretError::SafeExportSecretError(
+                StagedSafeExportSecretError::NotGroupMember,
+            )) => {
+                // Special case: the commit removes us from the PQ group.
+                //
+                // Skip PSK injection: the T group commit also removes us, so OpenMLS returns early
+                // before reaching the key schedule.
+            }
+            Err(e) => return Err(ApqPskError::ExportFromProcessed(e).into()),
+        }
     }
 
     let unverified_t_message =

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -258,15 +258,7 @@ impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for MessageInfo<F> {
 }
 
 impl ApqMlsGroup {
-    /// Parses incoming messages from the DS. Checks for syntactic errors and
-    /// makes some semantic checks as well. If the input is an encrypted
-    /// message, it will be decrypted. This processing function does syntactic
-    /// and semantic validation of the message. It returns a [ProcessedMessage]
-    /// enum.
-    ///
-    /// # Errors:
-    /// Returns an [`ProcessMessageError`] when the validation checks fail
-    /// with the exact reason of the failure.
+    /// See the free function [`process_message`].
     pub fn process_message<F, Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
@@ -276,127 +268,147 @@ impl ApqMlsGroup {
     where
         F: Fn(&Credential, &Credential) -> bool,
     {
-        let protocol_message: ApqProtocolMessage = message.into();
-        // We only export a PSK if we process a PQ message
-        let unverified_pq_message = self
-            .pq_group
-            .unprotect_message(provider, protocol_message.pq_protocol_message)?;
-        let pq_updates = extract_app_data_updates(&self.pq_group, &unverified_pq_message);
-        let mut pq_message = self
-            .pq_group
-            .process_unverified_message_with_app_data_updates(
-                provider,
-                unverified_pq_message,
-                pq_updates,
-            )?;
-
-        let msg_type = MessageType::new(pq_message.content(), &sender_equivalence)
-            .ok_or(ApqProcessMessageError::InvalidMessageType)?;
-        let pq_message_info = MessageInfo {
-            msg_type,
-            sender: pq_message.sender().clone(),
-        };
-
-        // If we have a commit message, we need to export the PSK
-        if matches!(
-            pq_message.content(),
-            ProcessedMessageContent::StagedCommitMessage(_)
-        ) {
-            let apq_exporter: Secret = pq_message
-                .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
-                .map_err(ApqPskError::ExportFromProcessed)?
-                .into();
-
-            let apq_psk_id = apq_exporter
-                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
-                .map_err(ApqPskError::DerivingPskId)?;
-            let apq_psk = apq_exporter
-                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
-                .map_err(ApqPskError::DerivingPskId)?;
-            drop(apq_exporter); // Zeroize the secret
-
-            let psk = Psk::Application(ApplicationPsk::new(
-                APQMLS_COMPONENT_ID,
-                apq_psk_id.as_slice().into(),
-            ));
-            let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
-                .map_err(ApqPskError::DerivingPskId)?;
-            store_psk(provider, id, apq_psk.as_slice())?;
-        }
-
-        let unverified_t_message = self
-            .t_group
-            .unprotect_message(provider, protocol_message.t_protocol_message)?;
-        let t_updates = extract_app_data_updates(&self.t_group, &unverified_t_message);
-        let t_message = self
-            .t_group
-            .process_unverified_message_with_app_data_updates(
-                provider,
-                unverified_t_message,
-                t_updates,
-            )?;
-
-        let msg_type = MessageType::new(t_message.content(), &sender_equivalence)
-            .ok_or(ApqProcessMessageError::InvalidMessageType)?;
-        let t_message_info = MessageInfo {
-            msg_type,
-            sender: t_message.sender().clone(),
-        };
-
-        // Make sure that messages match up
-        if pq_message_info != t_message_info {
-            return Err(ApqProcessMessageError::MismatchedMessages);
-        }
-
-        // If both are commits, the [`ApqInfo`] component must be updated and in
-        // line with the info of both groups
-        if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
-            && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) =
-                t_message.content()
-        {
-            let pq_apq_info =
-                ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
-                    .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
-                    .ok_or(ApqProcessMessageError::MissingApqInfo)?;
-            let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
-                .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
-                .ok_or(ApqProcessMessageError::MissingApqInfo)?;
-
-            // ApqInfo contents must match
-            let apq_info_match = pq_apq_info == t_apq_info;
-
-            // Epochs must be in line with the groups
-            let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
-                && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
-
-            // New epochs must be one higher than the current ones
-            let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64()
-                == self.pq_group.epoch().as_u64() + 1
-                && t_apq_info.t_epoch.as_u64() == self.t_group.epoch().as_u64() + 1;
-
-            // Group IDs must be in line with the groups
-            let group_ids_match = pq_apq_info.pq_session_group_id == *self.pq_group.group_id()
-                && t_apq_info.t_session_group_id == *self.t_group.group_id();
-
-            // Ciphersuites must be in line with the groups
-            let ciphersuites_match = pq_apq_info.pq_cipher_suite == self.pq_group.ciphersuite()
-                && t_apq_info.t_cipher_suite == self.t_group.ciphersuite();
-
-            if !apq_info_match
-                || !epochs_match
-                || !epochs_are_incremented
-                || !group_ids_match
-                || !ciphersuites_match
-            {
-                return Err(ApqProcessMessageError::InvalidApqInfo);
-            }
-        }
-
-        Ok(ApqProcessedMessage {
-            t_message,
-            pq_message,
-        })
+        process_message(
+            &mut self.t_group,
+            &mut self.pq_group,
+            provider,
+            message,
+            sender_equivalence,
+        )
     }
+}
+
+/// Processes an incoming APQMLS message.
+///
+/// Parses incoming messages from the DS. Checks for syntactic errors and makes some semantic checks
+/// as well. If the input is an encrypted message, it will be decrypted. This processing function
+/// does syntactic and semantic validation of the message. It returns a [ProcessedMessage] enum.
+///
+/// # Errors
+///
+/// Returns an [`ProcessMessageError`] when the validation checks fail with the exact reason of the
+/// failure.
+pub fn process_message<F, Provider: OpenMlsProvider>(
+    t_group: &mut MlsGroup,
+    pq_group: &mut MlsGroup,
+    provider: &Provider,
+    message: impl Into<ApqProtocolMessage>,
+    sender_equivalence: F,
+) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
+where
+    F: Fn(&Credential, &Credential) -> bool,
+{
+    let protocol_message: ApqProtocolMessage = message.into();
+    // We only export a PSK if we process a PQ message
+    let unverified_pq_message =
+        pq_group.unprotect_message(provider, protocol_message.pq_protocol_message)?;
+    let pq_updates = extract_app_data_updates(pq_group, &unverified_pq_message);
+    let mut pq_message = pq_group.process_unverified_message_with_app_data_updates(
+        provider,
+        unverified_pq_message,
+        pq_updates,
+    )?;
+
+    let msg_type = MessageType::new(pq_message.content(), &sender_equivalence)
+        .ok_or(ApqProcessMessageError::InvalidMessageType)?;
+    let pq_message_info = MessageInfo {
+        msg_type,
+        sender: pq_message.sender().clone(),
+    };
+
+    // If we have a commit message, we need to export the PSK
+    if matches!(
+        pq_message.content(),
+        ProcessedMessageContent::StagedCommitMessage(_)
+    ) {
+        let apq_exporter: Secret = pq_message
+            .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
+            .map_err(ApqPskError::ExportFromProcessed)?
+            .into();
+
+        let apq_psk_id = apq_exporter
+            .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk_id")
+            .map_err(ApqPskError::DerivingPskId)?;
+        let apq_psk = apq_exporter
+            .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk")
+            .map_err(ApqPskError::DerivingPskId)?;
+        drop(apq_exporter); // Zeroize the secret
+
+        let psk = Psk::Application(ApplicationPsk::new(
+            APQMLS_COMPONENT_ID,
+            apq_psk_id.as_slice().into(),
+        ));
+        let id = PreSharedKeyId::new(t_group.ciphersuite(), provider.rand(), psk)
+            .map_err(ApqPskError::DerivingPskId)?;
+        store_psk(provider, id, apq_psk.as_slice())?;
+    }
+
+    let unverified_t_message =
+        t_group.unprotect_message(provider, protocol_message.t_protocol_message)?;
+    let t_updates = extract_app_data_updates(t_group, &unverified_t_message);
+    let t_message = t_group.process_unverified_message_with_app_data_updates(
+        provider,
+        unverified_t_message,
+        t_updates,
+    )?;
+
+    let msg_type = MessageType::new(t_message.content(), &sender_equivalence)
+        .ok_or(ApqProcessMessageError::InvalidMessageType)?;
+    let t_message_info = MessageInfo {
+        msg_type,
+        sender: t_message.sender().clone(),
+    };
+
+    // Make sure that messages match up
+    if pq_message_info != t_message_info {
+        return Err(ApqProcessMessageError::MismatchedMessages);
+    }
+
+    // If both are commits, the [`ApqInfo`] component must be updated and in
+    // line with the info of both groups
+    if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
+        && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) = t_message.content()
+    {
+        let pq_apq_info = ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
+            .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
+            .ok_or(ApqProcessMessageError::MissingApqInfo)?;
+        let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
+            .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
+            .ok_or(ApqProcessMessageError::MissingApqInfo)?;
+
+        // ApqInfo contents must match
+        let apq_info_match = pq_apq_info == t_apq_info;
+
+        // Epochs must be in line with the groups
+        let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
+            && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
+
+        // New epochs must be one higher than the current ones
+        let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64() == pq_group.epoch().as_u64() + 1
+            && t_apq_info.t_epoch.as_u64() == t_group.epoch().as_u64() + 1;
+
+        // Group IDs must be in line with the groups
+        let group_ids_match = pq_apq_info.pq_session_group_id == *pq_group.group_id()
+            && t_apq_info.t_session_group_id == *t_group.group_id();
+
+        // Ciphersuites must be in line with the groups
+        let ciphersuites_match = pq_apq_info.pq_cipher_suite == pq_group.ciphersuite()
+            && t_apq_info.t_cipher_suite == t_group.ciphersuite();
+
+        if !apq_info_match
+            || !epochs_match
+            || !epochs_are_incremented
+            || !group_ids_match
+            || !ciphersuites_match
+        {
+            return Err(ApqProcessMessageError::InvalidApqInfo);
+        }
+    }
+
+    Ok(ApqProcessedMessage {
+        t_message,
+        pq_message,
+    })
 }
 
 fn extract_app_data_updates(

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -35,12 +35,6 @@ pub struct ApqProcessedMessage {
     pub pq_message: ProcessedMessage,
 }
 
-/// A bundle consisting of the processed public messages of both the traditional and the PQ group.
-pub struct ApqProcessedPublicMessage {
-    pub t_message: ProcessedMessage,
-    pub pq_message: ProcessedMessage,
-}
-
 /// A bundle consisting of the staged commits of both the traditional and the
 /// PQ group.
 pub struct ApqStagedCommit {
@@ -76,7 +70,7 @@ pub enum ApqProcessMessageError<StorageError> {
     Validation(#[from] ApqProcessMessageValidationError),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum ApqProcessPublicMessageError {
     #[error(transparent)]
     Processing(#[from] PublicProcessMessageError),
@@ -84,7 +78,7 @@ pub enum ApqProcessPublicMessageError {
     Validation(#[from] ApqProcessMessageValidationError),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
 pub enum ApqProcessMessageValidationError {
     #[error("The message type is invalid for processing.")]
     InvalidMessageType,
@@ -425,7 +419,7 @@ impl ApqPublicGroupMut<'_> {
         crypto: &Crypto,
         message: impl Into<ApqProtocolMessage>,
         sender_equivalence: F,
-    ) -> Result<ApqProcessedPublicMessage, ApqProcessPublicMessageError>
+    ) -> Result<ApqProcessedMessage, ApqProcessPublicMessageError>
     where
         F: Fn(&Credential, &Credential) -> bool,
     {
@@ -433,7 +427,7 @@ impl ApqPublicGroupMut<'_> {
 
         let pq_message = self
             .pq_public_group
-            .process_message(crypto, protocol_message.pq_protocol_message)?;
+            .process_message_with_app_data_updates(crypto, protocol_message.pq_protocol_message)?;
         let pq_message_info = MessageInfo::new(
             pq_message.content(),
             pq_message.sender().clone(),
@@ -442,7 +436,7 @@ impl ApqPublicGroupMut<'_> {
 
         let t_message = self
             .t_public_group
-            .process_message(crypto, protocol_message.t_protocol_message)?;
+            .process_message_with_app_data_updates(crypto, protocol_message.t_protocol_message)?;
         let t_message_info = MessageInfo::new(
             t_message.content(),
             t_message.sender().clone(),
@@ -460,7 +454,7 @@ impl ApqPublicGroupMut<'_> {
         let t_params = ValidationParams::from_public_group(self.t_public_group);
         ValidationParams::validate(pq_params, t_params, &pq_message, &t_message)?;
 
-        Ok(ApqProcessedPublicMessage {
+        Ok(ApqProcessedMessage {
             t_message,
             pq_message,
         })

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -7,9 +7,8 @@ use std::fmt::Debug;
 use openmls::{
     component::ComponentData,
     group::{
-        AppDataUpdates, GroupEpoch, GroupId, MlsGroup, ProcessMessageError,
-        ProcessedMessageSafeExportSecretError, PublicGroup, PublicProcessMessageError,
-        StagedCommit, StagedSafeExportSecretError,
+        AppDataUpdates, GroupEpoch, GroupId, MlsGroup, ProcessMessageError, PublicGroup,
+        PublicProcessMessageError, StagedCommit,
     },
     prelude::{
         AppDataUpdateOperation, Ciphersuite, Credential, LeafNodeIndex, OpenMlsCrypto,
@@ -352,41 +351,34 @@ impl ApqMlsGroupMut<'_> {
             &sender_equivalence,
         )?;
 
-        // If we have a commit message, we need to export the PSK
-        if matches!(
-            pq_message.content(),
-            ProcessedMessageContent::StagedCommitMessage(_)
-        ) {
-            match pq_message.safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID) {
-                Ok(apq_exporter_bytes) => {
-                    let apq_exporter: Secret = apq_exporter_bytes.into();
+        // If we have a commit message and it is not a self-removal, we need to export the PSK.
+        //
+        // Self-removal is a special case where PSK injection should be skipped: The T group commit
+        // also removes us, so OpenMLS returns early before reaching the key schedule.
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) = pq_message.content()
+            && !staged_commit.self_removed()
+        {
+            let apq_exporter_bytes = pq_message
+                .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
+                .map_err(ApqPskError::ExportFromProcessed)?;
 
-                    let apq_psk_id = apq_exporter
-                        .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
-                        .map_err(ApqPskError::DerivingPskId)?;
-                    let apq_psk = apq_exporter
-                        .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
-                        .map_err(ApqPskError::DerivingPskId)?;
-                    drop(apq_exporter); // Zeroize the secret
+            let apq_exporter: Secret = apq_exporter_bytes.into();
 
-                    let psk = Psk::Application(ApplicationPsk::new(
-                        APQMLS_COMPONENT_ID,
-                        apq_psk_id.as_slice().into(),
-                    ));
-                    let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
-                        .map_err(ApqPskError::DerivingPskId)?;
-                    store_psk(provider, id, apq_psk.as_slice())?;
-                }
-                Err(ProcessedMessageSafeExportSecretError::SafeExportSecretError(
-                    StagedSafeExportSecretError::NotGroupMember,
-                )) => {
-                    // Special case: the commit removes us from the PQ group.
-                    //
-                    // Skip PSK injection: the T group commit also removes us, so OpenMLS returns early
-                    // before reaching the key schedule.
-                }
-                Err(e) => return Err(ApqPskError::ExportFromProcessed(e).into()),
-            }
+            let apq_psk_id = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
+                .map_err(ApqPskError::DerivingPskId)?;
+            let apq_psk = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
+                .map_err(ApqPskError::DerivingPskId)?;
+            drop(apq_exporter); // Zeroize the secret
+
+            let psk = Psk::Application(ApplicationPsk::new(
+                APQMLS_COMPONENT_ID,
+                apq_psk_id.as_slice().into(),
+            ));
+            let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
+                .map_err(ApqPskError::DerivingPskId)?;
+            store_psk(provider, id, apq_psk.as_slice())?;
         }
 
         let unverified_t_message = self

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -7,13 +7,14 @@ use std::fmt::Debug;
 use openmls::{
     component::ComponentData,
     group::{
-        AppDataUpdates, MlsGroup, ProcessMessageError, ProcessedMessageSafeExportSecretError,
+        AppDataUpdates, GroupEpoch, GroupId, MlsGroup, ProcessMessageError,
+        ProcessedMessageSafeExportSecretError, PublicGroup, PublicProcessMessageError,
         StagedCommit, StagedSafeExportSecretError,
     },
     prelude::{
-        AppDataUpdateOperation, Credential, LeafNodeIndex, ProcessedMessage,
-        ProcessedMessageContent, Proposal, ProposalIn, ProposalOrRefIn, ProposalType, Sender,
-        UnverifiedMessage,
+        AppDataUpdateOperation, Ciphersuite, Credential, LeafNodeIndex, OpenMlsCrypto,
+        ProcessedMessage, ProcessedMessageContent, Proposal, ProposalIn, ProposalOrRefIn,
+        ProposalType, Sender, UnverifiedMessage,
     },
     schedule::{PreSharedKeyId, Psk, psk::ApplicationPsk},
     storage::OpenMlsProvider,
@@ -21,16 +22,22 @@ use openmls::{
 use thiserror::Error;
 
 use crate::{
-    ApqMlsGroup,
+    ApqMlsGroup, ApqMlsGroupMut,
     extension::{APQMLS_COMPONENT_ID, ApqInfo},
     messages::ApqProtocolMessage,
     psk::{ApqPskError, store_psk},
+    public_group::ApqPublicGroupMut,
     secret::Secret,
 };
 
-/// A bundle consisting of the processed messages of both the traditional and
-/// the PQ group.
+/// A bundle consisting of the processed messages of both the traditional and the PQ group.
 pub struct ApqProcessedMessage {
+    pub t_message: ProcessedMessage,
+    pub pq_message: ProcessedMessage,
+}
+
+/// A bundle consisting of the processed public messages of both the traditional and the PQ group.
+pub struct ApqProcessedPublicMessage {
     pub t_message: ProcessedMessage,
     pub pq_message: ProcessedMessage,
 }
@@ -66,6 +73,20 @@ pub enum ApqProcessMessageError<StorageError> {
     Processing(#[from] ProcessMessageError<StorageError>),
     #[error(transparent)]
     Psk(#[from] ApqPskError<StorageError>),
+    #[error(transparent)]
+    Validation(#[from] ApqProcessMessageValidationError),
+}
+
+#[derive(Debug, Error)]
+pub enum ApqProcessPublicMessageError {
+    #[error(transparent)]
+    Processing(#[from] PublicProcessMessageError),
+    #[error(transparent)]
+    Validation(#[from] ApqProcessMessageValidationError),
+}
+
+#[derive(Debug, Error)]
+pub enum ApqProcessMessageValidationError {
     #[error("The message type is invalid for processing.")]
     InvalidMessageType,
     #[error("The MLS messages don't match.")]
@@ -245,6 +266,21 @@ struct MessageInfo<F: Fn(&Credential, &Credential) -> bool> {
     sender: Sender,
 }
 
+impl<F: Fn(&Credential, &Credential) -> bool> MessageInfo<F> {
+    fn new(
+        content: &ProcessedMessageContent,
+        sender: Sender,
+        sender_equivalence: F,
+    ) -> Result<Self, ApqProcessMessageValidationError>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        let msg_type = MessageType::new(content, sender_equivalence)
+            .ok_or(ApqProcessMessageValidationError::InvalidMessageType)?;
+        Ok(Self { msg_type, sender })
+    }
+}
+
 impl<F: Fn(&Credential, &Credential) -> bool> Debug for MessageInfo<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MessageInfo")
@@ -261,7 +297,7 @@ impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for MessageInfo<F> {
 }
 
 impl ApqMlsGroup {
-    /// See the free function [`process_message`].
+    /// See [`ApqMlsGroupMut::process_message`].
     pub fn process_message<F, Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
@@ -271,157 +307,250 @@ impl ApqMlsGroup {
     where
         F: Fn(&Credential, &Credential) -> bool,
     {
-        process_message(
-            &mut self.t_group,
-            &mut self.pq_group,
-            provider,
-            message,
-            sender_equivalence,
-        )
+        self.as_mut()
+            .process_message(provider, message, sender_equivalence)
     }
 }
 
-/// Processes an incoming APQMLS message.
-///
-/// Parses incoming messages from the DS. Checks for syntactic errors and makes some semantic checks
-/// as well. If the input is an encrypted message, it will be decrypted. This processing function
-/// does syntactic and semantic validation of the message. It returns a [ProcessedMessage] enum.
-///
-/// # Errors
-///
-/// Returns an [`ProcessMessageError`] when the validation checks fail with the exact reason of the
-/// failure.
-pub fn process_message<F, Provider: OpenMlsProvider>(
-    t_group: &mut MlsGroup,
-    pq_group: &mut MlsGroup,
-    provider: &Provider,
-    message: impl Into<ApqProtocolMessage>,
-    sender_equivalence: F,
-) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
-where
-    F: Fn(&Credential, &Credential) -> bool,
-{
-    let protocol_message: ApqProtocolMessage = message.into();
-    // We only export a PSK if we process a PQ message
-    let unverified_pq_message =
-        pq_group.unprotect_message(provider, protocol_message.pq_protocol_message)?;
-    let pq_updates = extract_app_data_updates(pq_group, &unverified_pq_message);
-    let mut pq_message = pq_group.process_unverified_message_with_app_data_updates(
-        provider,
-        unverified_pq_message,
-        pq_updates,
-    )?;
-
-    let msg_type = MessageType::new(pq_message.content(), &sender_equivalence)
-        .ok_or(ApqProcessMessageError::InvalidMessageType)?;
-    let pq_message_info = MessageInfo {
-        msg_type,
-        sender: pq_message.sender().clone(),
-    };
-
-    // If we have a commit message, we need to export the PSK
-    if matches!(
-        pq_message.content(),
-        ProcessedMessageContent::StagedCommitMessage(_)
-    ) {
-        match pq_message.safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID) {
-            Ok(apq_exporter_bytes) => {
-                let apq_exporter: Secret = apq_exporter_bytes.into();
-
-                let apq_psk_id = apq_exporter
-                    .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk_id")
-                    .map_err(ApqPskError::DerivingPskId)?;
-                let apq_psk = apq_exporter
-                    .derive_secret(provider.crypto(), t_group.ciphersuite(), "psk")
-                    .map_err(ApqPskError::DerivingPskId)?;
-                drop(apq_exporter); // Zeroize the secret
-
-                let psk = Psk::Application(ApplicationPsk::new(
-                    APQMLS_COMPONENT_ID,
-                    apq_psk_id.as_slice().into(),
-                ));
-                let id = PreSharedKeyId::new(t_group.ciphersuite(), provider.rand(), psk)
-                    .map_err(ApqPskError::DerivingPskId)?;
-                store_psk(provider, id, apq_psk.as_slice())?;
-            }
-            Err(ProcessedMessageSafeExportSecretError::SafeExportSecretError(
-                StagedSafeExportSecretError::NotGroupMember,
-            )) => {
-                // Special case: the commit removes us from the PQ group.
-                //
-                // Skip PSK injection: the T group commit also removes us, so OpenMLS returns early
-                // before reaching the key schedule.
-            }
-            Err(e) => return Err(ApqPskError::ExportFromProcessed(e).into()),
-        }
-    }
-
-    let unverified_t_message =
-        t_group.unprotect_message(provider, protocol_message.t_protocol_message)?;
-    let t_updates = extract_app_data_updates(t_group, &unverified_t_message);
-    let t_message = t_group.process_unverified_message_with_app_data_updates(
-        provider,
-        unverified_t_message,
-        t_updates,
-    )?;
-
-    let msg_type = MessageType::new(t_message.content(), &sender_equivalence)
-        .ok_or(ApqProcessMessageError::InvalidMessageType)?;
-    let t_message_info = MessageInfo {
-        msg_type,
-        sender: t_message.sender().clone(),
-    };
-
-    // Make sure that messages match up
-    if pq_message_info != t_message_info {
-        return Err(ApqProcessMessageError::MismatchedMessages);
-    }
-
-    // If both are commits, the [`ApqInfo`] component must be updated and in
-    // line with the info of both groups
-    if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
-        && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) = t_message.content()
+impl ApqMlsGroupMut<'_> {
+    /// Processes an incoming APQMLS message.
+    ///
+    /// Parses incoming messages from the DS. Checks for syntactic errors and makes some semantic checks
+    /// as well. If the input is an encrypted message, it will be decrypted. This processing function
+    /// does syntactic and semantic validation of the message. It returns a [ProcessedMessage] enum.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ProcessMessageError`] when the validation checks fail with the exact reason of the
+    /// failure.
+    pub fn process_message<F, Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+        message: impl Into<ApqProtocolMessage>,
+        sender_equivalence: F,
+    ) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
     {
-        let pq_apq_info = ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
-            .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
-            .ok_or(ApqProcessMessageError::MissingApqInfo)?;
-        let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
-            .map_err(|_| ApqProcessMessageError::InvalidApqInfo)?
-            .ok_or(ApqProcessMessageError::MissingApqInfo)?;
+        let protocol_message: ApqProtocolMessage = message.into();
+        // We only export a PSK if we process a PQ message
+        let unverified_pq_message = self
+            .pq_group
+            .unprotect_message(provider, protocol_message.pq_protocol_message)?;
+        let pq_updates = extract_app_data_updates(self.pq_group, &unverified_pq_message);
+        let mut pq_message = self
+            .pq_group
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_pq_message,
+                pq_updates,
+            )?;
 
-        // ApqInfo contents must match
-        let apq_info_match = pq_apq_info == t_apq_info;
+        let pq_message_info = MessageInfo::new(
+            pq_message.content(),
+            pq_message.sender().clone(),
+            &sender_equivalence,
+        )?;
 
-        // Epochs must be in line with the groups
-        let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
-            && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
+        // If we have a commit message, we need to export the PSK
+        if matches!(
+            pq_message.content(),
+            ProcessedMessageContent::StagedCommitMessage(_)
+        ) {
+            match pq_message.safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID) {
+                Ok(apq_exporter_bytes) => {
+                    let apq_exporter: Secret = apq_exporter_bytes.into();
 
-        // New epochs must be one higher than the current ones
-        let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64() == pq_group.epoch().as_u64() + 1
-            && t_apq_info.t_epoch.as_u64() == t_group.epoch().as_u64() + 1;
+                    let apq_psk_id = apq_exporter
+                        .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
+                        .map_err(ApqPskError::DerivingPskId)?;
+                    let apq_psk = apq_exporter
+                        .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
+                        .map_err(ApqPskError::DerivingPskId)?;
+                    drop(apq_exporter); // Zeroize the secret
 
-        // Group IDs must be in line with the groups
-        let group_ids_match = pq_apq_info.pq_session_group_id == *pq_group.group_id()
-            && t_apq_info.t_session_group_id == *t_group.group_id();
+                    let psk = Psk::Application(ApplicationPsk::new(
+                        APQMLS_COMPONENT_ID,
+                        apq_psk_id.as_slice().into(),
+                    ));
+                    let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
+                        .map_err(ApqPskError::DerivingPskId)?;
+                    store_psk(provider, id, apq_psk.as_slice())?;
+                }
+                Err(ProcessedMessageSafeExportSecretError::SafeExportSecretError(
+                    StagedSafeExportSecretError::NotGroupMember,
+                )) => {
+                    // Special case: the commit removes us from the PQ group.
+                    //
+                    // Skip PSK injection: the T group commit also removes us, so OpenMLS returns early
+                    // before reaching the key schedule.
+                }
+                Err(e) => return Err(ApqPskError::ExportFromProcessed(e).into()),
+            }
+        }
 
-        // Ciphersuites must be in line with the groups
-        let ciphersuites_match = pq_apq_info.pq_cipher_suite == pq_group.ciphersuite()
-            && t_apq_info.t_cipher_suite == t_group.ciphersuite();
+        let unverified_t_message = self
+            .t_group
+            .unprotect_message(provider, protocol_message.t_protocol_message)?;
+        let t_updates = extract_app_data_updates(self.t_group, &unverified_t_message);
+        let t_message = self
+            .t_group
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_t_message,
+                t_updates,
+            )?;
 
-        if !apq_info_match
-            || !epochs_match
-            || !epochs_are_incremented
-            || !group_ids_match
-            || !ciphersuites_match
-        {
-            return Err(ApqProcessMessageError::InvalidApqInfo);
+        let t_message_info = MessageInfo::new(
+            t_message.content(),
+            t_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        // Make sure that messages match up
+        if pq_message_info != t_message_info {
+            return Err(ApqProcessMessageValidationError::MismatchedMessages.into());
+        }
+
+        let pq_params = ValidationParams::from_mls_group(self.pq_group);
+        let t_params = ValidationParams::from_mls_group(self.t_group);
+        ValidationParams::validate(pq_params, t_params, &pq_message, &t_message)?;
+
+        Ok(ApqProcessedMessage {
+            t_message,
+            pq_message,
+        })
+    }
+}
+
+impl ApqPublicGroupMut<'_> {
+    /// Processes an incoming public AQPMLS message.
+    ///
+    /// Validates both messages, checks T/PQ consistency (same operator/sender), ApqInfo
+    /// epoch/group-id/ciphersuite invariants). No PSK derivation is performed.
+    pub fn process_message<Crypto: OpenMlsCrypto, F>(
+        &mut self,
+        crypto: &Crypto,
+        message: impl Into<ApqProtocolMessage>,
+        sender_equivalence: F,
+    ) -> Result<ApqProcessedPublicMessage, ApqProcessPublicMessageError>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        let protocol_message: ApqProtocolMessage = message.into();
+
+        let pq_message = self
+            .pq_public_group
+            .process_message(crypto, protocol_message.pq_protocol_message)?;
+        let pq_message_info = MessageInfo::new(
+            pq_message.content(),
+            pq_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        let t_message = self
+            .t_public_group
+            .process_message(crypto, protocol_message.t_protocol_message)?;
+        let t_message_info = MessageInfo::new(
+            t_message.content(),
+            t_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        // Note: no PSK export/store
+
+        // Make sure that messages match up
+        if pq_message_info != t_message_info {
+            return Err(ApqProcessMessageValidationError::MismatchedMessages.into());
+        }
+
+        let pq_params = ValidationParams::from_public_group(self.pq_public_group);
+        let t_params = ValidationParams::from_public_group(self.t_public_group);
+        ValidationParams::validate(pq_params, t_params, &pq_message, &t_message)?;
+
+        Ok(ApqProcessedPublicMessage {
+            t_message,
+            pq_message,
+        })
+    }
+}
+
+struct ValidationParams<'a> {
+    epoch: GroupEpoch,
+    group_id: &'a GroupId,
+    ciphersuite: Ciphersuite,
+}
+
+impl<'a> ValidationParams<'a> {
+    fn from_mls_group(group: &'a MlsGroup) -> Self {
+        Self {
+            epoch: group.epoch(),
+            group_id: group.group_id(),
+            ciphersuite: group.ciphersuite(),
         }
     }
 
-    Ok(ApqProcessedMessage {
-        t_message,
-        pq_message,
-    })
+    fn from_public_group(group: &'a PublicGroup) -> Self {
+        Self {
+            epoch: group.group_context().epoch(),
+            group_id: group.group_context().group_id(),
+            ciphersuite: group.group_context().ciphersuite(),
+        }
+    }
+
+    fn validate(
+        pq_params: Self,
+        t_params: Self,
+        pq_message: &ProcessedMessage,
+        t_message: &ProcessedMessage,
+    ) -> Result<(), ApqProcessMessageValidationError> {
+        use ApqProcessMessageValidationError::*;
+
+        // If both are commits, the [`ApqInfo`] component must be in line with the info of both groups
+        if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
+            && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) =
+                t_message.content()
+        {
+            let pq_apq_info =
+                ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
+                    .map_err(|_| InvalidApqInfo)?
+                    .ok_or(MissingApqInfo)?;
+            let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
+                .map_err(|_| InvalidApqInfo)?
+                .ok_or(MissingApqInfo)?;
+
+            // ApqInfo contents must match
+            let apq_info_match = pq_apq_info == t_apq_info;
+
+            // Epochs must be in line with the groups
+            let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
+                && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
+
+            // New epochs must be one higher than the current ones
+            let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64()
+                == pq_params.epoch.as_u64() + 1
+                && t_apq_info.t_epoch.as_u64() == t_params.epoch.as_u64() + 1;
+
+            // Group IDs must be in line with the groups
+            let group_ids_match = pq_apq_info.pq_session_group_id == *pq_params.group_id
+                && t_apq_info.t_session_group_id == *t_params.group_id;
+
+            // Ciphersuites must be in line with the groups
+            let ciphersuites_match = pq_apq_info.pq_cipher_suite == pq_params.ciphersuite
+                && t_apq_info.t_cipher_suite == t_params.ciphersuite;
+
+            if !apq_info_match
+                || !epochs_match
+                || !epochs_are_incremented
+                || !group_ids_match
+                || !ciphersuites_match
+            {
+                return Err(InvalidApqInfo);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn extract_app_data_updates(

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -310,7 +310,7 @@ impl ApqMlsGroupMut<'_> {
     ///
     /// Parses incoming messages from the DS. Checks for syntactic errors and makes some semantic checks
     /// as well. If the input is an encrypted message, it will be decrypted. This processing function
-    /// does syntactic and semantic validation of the message. It returns a [ProcessedMessage] enum.
+    /// does syntactic and semantic validation of the message. It returns a [`ProcessedMessage`] enum.
     ///
     /// # Errors
     ///

--- a/src/public_group.rs
+++ b/src/public_group.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::group::PublicGroup;
+
+/// An APQMLS public group, consisting of a traditional public group and a post-quantum public
+/// group.
+///
+/// The two groups can be used independently, except for membership updates.
+#[derive(Debug)]
+pub struct ApqPublicGroup {
+    t_public_group: PublicGroup,
+    pq_public_group: PublicGroup,
+}
+
+/// Same as [`ApqPublicGroup`], but references public groups instead of owning them.
+#[derive(Debug)]
+pub struct ApqPublicGroupMut<'a> {
+    pub(crate) t_public_group: &'a mut PublicGroup,
+    pub(crate) pq_public_group: &'a mut PublicGroup,
+}
+
+impl ApqPublicGroup {
+    /// Create a new APQMLS public group from the traditional and post-quantum MLS public groups.
+    pub fn from_groups(t_public_group: PublicGroup, pq_public_group: PublicGroup) -> Self {
+        Self {
+            t_public_group,
+            pq_public_group,
+        }
+    }
+
+    pub fn as_mut(&mut self) -> ApqPublicGroupMut<'_> {
+        ApqPublicGroupMut::from_groups(&mut self.t_public_group, &mut self.pq_public_group)
+    }
+}
+
+impl<'a> ApqPublicGroupMut<'a> {
+    /// A non-owning version of [`ApqPublicGroup::from_groups`].
+    pub fn from_groups(
+        t_public_group: &'a mut PublicGroup,
+        pq_public_group: &'a mut PublicGroup,
+    ) -> Self {
+        Self {
+            t_public_group,
+            pq_public_group,
+        }
+    }
+
+    pub fn t_public_group(&mut self) -> &mut PublicGroup {
+        self.t_public_group
+    }
+
+    pub fn pq_public_group(&mut self) -> &mut PublicGroup {
+        self.pq_public_group
+    }
+}

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -4,8 +4,8 @@
 
 use openmls::{
     group::{
-        JoinBuilder as OpenMlsJoinBuilder, LeafNodeLifetimePolicy, MlsGroupJoinConfig,
-        MlsGroup, ProcessedWelcome, StagedWelcome, WelcomeError as OpenMlsWelcomeError,
+        JoinBuilder as OpenMlsJoinBuilder, LeafNodeLifetimePolicy, MlsGroup, MlsGroupJoinConfig,
+        ProcessedWelcome, StagedWelcome, WelcomeError as OpenMlsWelcomeError,
     },
     prelude::Ciphersuite,
     storage::OpenMlsProvider,

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
-    group::{MlsGroupJoinConfig, StagedWelcome, WelcomeError as OpenMlsWelcomeError},
+    group::{
+        JoinBuilder as OpenMlsJoinBuilder, LeafNodeLifetimePolicy, MlsGroupJoinConfig,
+        MlsGroup, ProcessedWelcome, StagedWelcome, WelcomeError as OpenMlsWelcomeError,
+    },
+    prelude::Ciphersuite,
     storage::OpenMlsProvider,
 };
 use thiserror::Error;
@@ -30,6 +34,81 @@ pub struct StagedApqWelcome {
     pq_staged_welcome: StagedWelcome,
 }
 
+/// Builder for joining an APQ group.
+pub struct JoinBuilder<'a, Provider: OpenMlsProvider> {
+    provider: &'a Provider,
+    t_processed_welcome: ProcessedWelcome,
+    pq_processed_welcome: ProcessedWelcome,
+    t_ciphersuite: Ciphersuite,
+    ratchet_tree: Option<ApqRatchetTreeIn>,
+    validate_lifetimes: LeafNodeLifetimePolicy,
+}
+
+impl<'a, Provider: OpenMlsProvider> JoinBuilder<'a, Provider> {
+    pub fn new(
+        provider: &'a Provider,
+        t_processed_welcome: ProcessedWelcome,
+        pq_processed_welcome: ProcessedWelcome,
+        t_ciphersuite: Ciphersuite,
+    ) -> Self {
+        Self {
+            provider,
+            t_processed_welcome,
+            pq_processed_welcome,
+            t_ciphersuite,
+            ratchet_tree: None,
+            validate_lifetimes: LeafNodeLifetimePolicy::Verify,
+        }
+    }
+
+    pub fn with_ratchet_tree(mut self, ratchet_tree: ApqRatchetTreeIn) -> Self {
+        self.ratchet_tree = Some(ratchet_tree);
+        self
+    }
+
+    pub fn skip_lifetime_validation(mut self) -> Self {
+        self.validate_lifetimes = LeafNodeLifetimePolicy::Skip;
+        self
+    }
+
+    pub fn build(self) -> Result<ApqMlsGroup, WelcomeError<Provider::StorageError>> {
+        let (t_ratchet_tree, pq_ratchet_tree) = self.ratchet_tree.map(|t| t.split()).unzip();
+
+        let mut pq_builder = OpenMlsJoinBuilder::new(self.provider, self.pq_processed_welcome);
+        if let Some(ratchet_tree) = pq_ratchet_tree {
+            pq_builder = pq_builder.with_ratchet_tree(ratchet_tree);
+        };
+        pq_builder = match self.validate_lifetimes {
+            LeafNodeLifetimePolicy::Skip => pq_builder.skip_lifetime_validation(),
+            LeafNodeLifetimePolicy::Verify => pq_builder,
+        };
+        let mut pq_group = pq_builder.build()?.into_group(self.provider)?;
+
+        derive_and_store_psk::<_, false>(self.provider, &mut pq_group, self.t_ciphersuite)?;
+
+        let mut t_builder = OpenMlsJoinBuilder::new(self.provider, self.t_processed_welcome);
+        if let Some(ratchet_tree) = t_ratchet_tree {
+            t_builder = t_builder.with_ratchet_tree(ratchet_tree);
+        };
+        t_builder = match self.validate_lifetimes {
+            LeafNodeLifetimePolicy::Skip => t_builder.skip_lifetime_validation(),
+            LeafNodeLifetimePolicy::Verify => t_builder,
+        };
+        let t_group = t_builder.build()?.into_group(self.provider)?;
+
+        Ok(ApqMlsGroup { t_group, pq_group })
+    }
+}
+
+pub fn derive_and_store_join_psk<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    pq_group: &mut MlsGroup,
+    t_ciphersuite: Ciphersuite,
+) -> Result<(), WelcomeError<Provider::StorageError>> {
+    derive_and_store_psk::<_, false>(provider, pq_group, t_ciphersuite)?;
+    Ok(())
+}
+
 impl ApqMlsGroup {
     /// Creates a new [`ApqMlsGroup`] from a welcome message.
     // TODO: Split into sans-io friendly parts.
@@ -43,13 +122,13 @@ impl ApqMlsGroup {
             Some(r) => (Some(r.t_ratchet_tree), Some(r.pq_ratchet_tree)),
             None => (None, None),
         };
-        let pq_staged_welcome = StagedWelcome::new_from_welcome(
+        let mut pq_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_config,
             welcome.pq_welcome,
             pq_ratchet_tree,
-        )?;
-        let mut pq_group = pq_staged_welcome.into_group(provider)?;
+        )?
+        .into_group(provider)?;
 
         let t_ciphersuite = welcome.t_welcome.ciphersuite();
 

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
-    group::{
-        JoinBuilder as OpenMlsJoinBuilder, LeafNodeLifetimePolicy, MlsGroup, MlsGroupJoinConfig,
-        ProcessedWelcome, StagedWelcome, WelcomeError as OpenMlsWelcomeError,
-    },
+    group::{MlsGroup, MlsGroupJoinConfig, StagedWelcome, WelcomeError as OpenMlsWelcomeError},
     prelude::Ciphersuite,
     storage::OpenMlsProvider,
 };
@@ -32,72 +29,6 @@ pub enum WelcomeError<StorageError> {
 pub struct StagedApqWelcome {
     t_staged_welcome: StagedWelcome,
     pq_staged_welcome: StagedWelcome,
-}
-
-/// Builder for joining an APQ group.
-pub struct JoinBuilder<'a, Provider: OpenMlsProvider> {
-    provider: &'a Provider,
-    t_processed_welcome: ProcessedWelcome,
-    pq_processed_welcome: ProcessedWelcome,
-    t_ciphersuite: Ciphersuite,
-    ratchet_tree: Option<ApqRatchetTreeIn>,
-    validate_lifetimes: LeafNodeLifetimePolicy,
-}
-
-impl<'a, Provider: OpenMlsProvider> JoinBuilder<'a, Provider> {
-    pub fn new(
-        provider: &'a Provider,
-        t_processed_welcome: ProcessedWelcome,
-        pq_processed_welcome: ProcessedWelcome,
-        t_ciphersuite: Ciphersuite,
-    ) -> Self {
-        Self {
-            provider,
-            t_processed_welcome,
-            pq_processed_welcome,
-            t_ciphersuite,
-            ratchet_tree: None,
-            validate_lifetimes: LeafNodeLifetimePolicy::Verify,
-        }
-    }
-
-    pub fn with_ratchet_tree(mut self, ratchet_tree: ApqRatchetTreeIn) -> Self {
-        self.ratchet_tree = Some(ratchet_tree);
-        self
-    }
-
-    pub fn skip_lifetime_validation(mut self) -> Self {
-        self.validate_lifetimes = LeafNodeLifetimePolicy::Skip;
-        self
-    }
-
-    pub fn build(self) -> Result<ApqMlsGroup, WelcomeError<Provider::StorageError>> {
-        let (t_ratchet_tree, pq_ratchet_tree) = self.ratchet_tree.map(|t| t.split()).unzip();
-
-        let mut pq_builder = OpenMlsJoinBuilder::new(self.provider, self.pq_processed_welcome);
-        if let Some(ratchet_tree) = pq_ratchet_tree {
-            pq_builder = pq_builder.with_ratchet_tree(ratchet_tree);
-        };
-        pq_builder = match self.validate_lifetimes {
-            LeafNodeLifetimePolicy::Skip => pq_builder.skip_lifetime_validation(),
-            LeafNodeLifetimePolicy::Verify => pq_builder,
-        };
-        let mut pq_group = pq_builder.build()?.into_group(self.provider)?;
-
-        derive_and_store_psk::<_, false>(self.provider, &mut pq_group, self.t_ciphersuite)?;
-
-        let mut t_builder = OpenMlsJoinBuilder::new(self.provider, self.t_processed_welcome);
-        if let Some(ratchet_tree) = t_ratchet_tree {
-            t_builder = t_builder.with_ratchet_tree(ratchet_tree);
-        };
-        t_builder = match self.validate_lifetimes {
-            LeafNodeLifetimePolicy::Skip => t_builder.skip_lifetime_validation(),
-            LeafNodeLifetimePolicy::Verify => t_builder,
-        };
-        let t_group = t_builder.build()?.into_group(self.provider)?;
-
-        Ok(ApqMlsGroup { t_group, pq_group })
-    }
 }
 
 pub fn derive_and_store_join_psk<Provider: OpenMlsProvider>(

--- a/tests/group_builder.rs
+++ b/tests/group_builder.rs
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::{
+    ApqMlsGroup,
+    extension::{APQMLS_COMPONENT_ID, PqtMode},
+    messages::{ApqMlsMessageIn, ApqRatchetTreeIn, ApqWelcome},
+};
+use openmls::{
+    component::{ComponentId, ComponentType},
+    group::{GroupContext, GroupId, MlsGroupJoinConfig},
+    prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, OpenMlsProvider,
+    },
+};
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use tls_codec::Deserialize as _;
+
+use crate::utils::{assert_groups_eq, client::Client};
+
+mod utils;
+
+const MODE: PqtMode = PqtMode::ConfAndAuth;
+
+fn build_group(
+    t_extensions: Option<Extensions<GroupContext>>,
+    pq_extensions: Option<Extensions<GroupContext>>,
+) -> (Client<OpenMlsRustCrypto>, ApqMlsGroup) {
+    let ciphersuite = MODE.default_ciphersuite();
+    let alice = Client::new("Alice", ciphersuite.into(), OpenMlsRustCrypto::default());
+
+    let mut builder = ApqMlsGroup::builder()
+        .with_group_ids(
+            GroupId::random(alice.provider.rand()),
+            GroupId::from_slice(b"test_pq_group"),
+        )
+        .set_mode(MODE);
+    if t_extensions.is_some() || pq_extensions.is_some() {
+        builder = builder
+            .with_group_context_extensions(
+                t_extensions.unwrap_or_default(),
+                pq_extensions.unwrap_or_default(),
+            )
+            .unwrap();
+    }
+    let group = builder
+        .build(
+            &alice.provider,
+            &alice.signer,
+            alice.credential_with_key.clone(),
+        )
+        .unwrap();
+    (alice, group)
+}
+
+fn dictionary_with(component_id: ComponentId) -> Extensions<GroupContext> {
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(component_id, Vec::new());
+    Extensions::from_vec(vec![Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    )])
+    .unwrap()
+}
+
+fn context_dictionary(context: &GroupContext) -> &AppDataDictionary {
+    context
+        .extensions()
+        .app_data_dictionary()
+        .expect("group context has no app data dictionary")
+        .dictionary()
+}
+
+fn app_components(dictionary: &AppDataDictionary) -> Vec<ComponentId> {
+    let bytes = dictionary
+        .get(&ComponentId::from(ComponentType::AppComponents))
+        .expect("no AppComponents entry");
+    Vec::tls_deserialize_exact(bytes).unwrap()
+}
+
+/// Default behavior (no caller dictionary): both group contexts advertise the
+/// APQMLS component and carry the ApqInfo entry; SafeAAD is not required.
+#[test]
+fn default_dictionary() {
+    let (_, group) = build_group(None, None);
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        let dictionary = context_dictionary(context);
+        assert!(app_components(dictionary).contains(&APQMLS_COMPONENT_ID));
+        assert!(dictionary.contains(&APQMLS_COMPONENT_ID));
+        assert!(!context.safe_aad_required());
+    }
+}
+
+/// A caller-provided dictionary entry survives the build and is merged with
+/// the APQMLS entries instead of being clobbered.
+#[test]
+fn caller_dictionary_is_merged() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (_, group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        let dictionary = context_dictionary(context);
+        // Caller entry survived ...
+        assert!(context.safe_aad_required());
+        // ... and the APQMLS entries are still there.
+        assert!(app_components(dictionary).contains(&APQMLS_COMPONENT_ID));
+        assert!(dictionary.contains(&APQMLS_COMPONENT_ID));
+    }
+}
+
+/// A caller-provided AppComponents list is extended, not overwritten.
+#[test]
+fn caller_app_components_are_merged() {
+    const CALLER_COMPONENT_ID: ComponentId = 0x9000;
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(
+        ComponentId::from(ComponentType::AppComponents),
+        tls_codec::Serialize::tls_serialize_detached(&[CALLER_COMPONENT_ID].as_slice()).unwrap(),
+    );
+    let extensions = Extensions::from_vec(vec![Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    )])
+    .unwrap();
+
+    let (_, group) = build_group(Some(extensions), None);
+
+    let components = app_components(context_dictionary(group.t_group.export_group_context()));
+    assert!(components.contains(&CALLER_COMPONENT_ID));
+    assert!(components.contains(&APQMLS_COMPONENT_ID));
+}
+
+/// Extensions are per-group: a dictionary provided only for the T group does
+/// not leak into the PQ group.
+#[test]
+fn asymmetric_extensions() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (_, group) = build_group(Some(dictionary_with(safe_aad)), None);
+
+    assert!(group.t_group.export_group_context().safe_aad_required());
+    assert!(!group.pq_group().export_group_context().safe_aad_required());
+    // Both still carry the APQMLS entries.
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        assert!(dictionary_contains_apq_info(context));
+    }
+}
+
+/// The caller entry survives a commit: the commit-path dictionary updater must
+/// produce only the ApqInfo delta, leaving foreign entries in place.
+#[test]
+fn caller_entry_survives_commit() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (alice, mut group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+
+    group
+        .commit_builder()
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+    group.merge_pending_commit(&alice.provider).unwrap();
+
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        assert!(context.safe_aad_required());
+        assert!(dictionary_contains_apq_info(context));
+    }
+}
+
+fn dictionary_contains_apq_info(context: &GroupContext) -> bool {
+    context_dictionary(context).contains(&APQMLS_COMPONENT_ID)
+}
+
+/// Adds Bob to Alice's group; returns the welcome and the ratchet tree.
+fn add_member(
+    alice: &Client<OpenMlsRustCrypto>,
+    alice_group: &mut ApqMlsGroup,
+    bob: &Client<OpenMlsRustCrypto>,
+) -> (ApqWelcome, ApqRatchetTreeIn) {
+    let key_package = bob.generate_key_package(MODE.default_ciphersuite());
+    let bundle = alice_group
+        .commit_builder()
+        .propose_adds([key_package])
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+    alice_group.merge_pending_commit(&alice.provider).unwrap();
+    let ratchet_tree = alice_group.export_ratchet_tree();
+    (bundle.into_welcome().unwrap(), ratchet_tree.into())
+}
+
+fn assert_joiner_inherited_dictionary(alice_group: &ApqMlsGroup, bob_group: &ApqMlsGroup) {
+    for (alice_context, bob_context) in [
+        (
+            alice_group.t_group.export_group_context(),
+            bob_group.t_group.export_group_context(),
+        ),
+        (
+            alice_group.pq_group().export_group_context(),
+            bob_group.pq_group().export_group_context(),
+        ),
+    ] {
+        assert!(bob_context.safe_aad_required());
+        assert_eq!(
+            context_dictionary(alice_context),
+            context_dictionary(bob_context)
+        );
+    }
+}
+
+/// A joiner via `ApqMlsGroup::new_from_welcome` inherits the creator's merged
+/// dictionary (incl. the SafeAad entry) through the welcome.
+#[test]
+fn joiner_inherits_dictionary_via_new_from_welcome() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (alice, mut alice_group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+
+    let bob = Client::new(
+        "Bob",
+        MODE.default_ciphersuite().into(),
+        OpenMlsRustCrypto::default(),
+    );
+    let (welcome, ratchet_tree) = add_member(&alice, &mut alice_group, &bob);
+
+    let mut bob_group = ApqMlsGroup::new_from_welcome(
+        &bob.provider,
+        &MlsGroupJoinConfig::default(),
+        welcome,
+        Some(ratchet_tree),
+    )
+    .unwrap();
+
+    assert_joiner_inherited_dictionary(&alice_group, &bob_group);
+    assert_group_operational(&alice, &mut alice_group, &bob, &mut bob_group);
+}
+
+/// Verifies the joined group is fully operational, beyond context contents:
+/// shared group state, correct membership, and commits flowing in both
+/// directions after the join.
+fn assert_group_operational(
+    alice: &Client<OpenMlsRustCrypto>,
+    alice_group: &mut ApqMlsGroup,
+    bob: &Client<OpenMlsRustCrypto>,
+    bob_group: &mut ApqMlsGroup,
+) {
+    // Same groups and epochs on both sides.
+    assert_eq!(alice_group.t_group.group_id(), bob_group.t_group.group_id());
+    assert_eq!(
+        alice_group.pq_group().group_id(),
+        bob_group.pq_group().group_id()
+    );
+    assert_eq!(alice_group.t_group.epoch(), bob_group.t_group.epoch());
+    assert_eq!(alice_group.pq_group().epoch(), bob_group.pq_group().epoch());
+
+    // Both members are present in both views.
+    for group in [&*alice_group, &*bob_group] {
+        assert_eq!(group.t_group.members().count(), 2);
+        assert_eq!(group.pq_group().members().count(), 2);
+    }
+
+    // Epoch secrets agree (this is what proves the joiner's PSK derivation
+    // between the PQ and T joins actually worked).
+    assert_groups_eq(alice_group, bob_group);
+
+    // Bob commits a self-update; Alice processes and merges it.
+    commit_and_process(bob, bob_group, alice, alice_group);
+    // And the other direction.
+    commit_and_process(alice, alice_group, bob, bob_group);
+
+    // The SafeAad requirement survived both post-join commits.
+    assert!(
+        bob_group
+            .t_group
+            .export_group_context()
+            .safe_aad_required()
+    );
+}
+
+/// `committer` creates and merges a self-update commit; `processor` processes
+/// and merges it. Asserts both views agree afterwards.
+fn commit_and_process(
+    committer: &Client<OpenMlsRustCrypto>,
+    committer_group: &mut ApqMlsGroup,
+    processor: &Client<OpenMlsRustCrypto>,
+    processor_group: &mut ApqMlsGroup,
+) {
+    let bundle = committer_group
+        .commit_builder()
+        .force_self_update(true)
+        .finalize(&committer.provider, &committer.signer, |_| true, |_| true)
+        .unwrap();
+    committer_group
+        .merge_pending_commit(&committer.provider)
+        .unwrap();
+
+    let protocol_message = ApqMlsMessageIn::try_from(bundle.commit)
+        .unwrap()
+        .into_protocol_message()
+        .unwrap();
+    let processed = processor_group
+        .process_message(&processor.provider, protocol_message, |cred1, cred2| {
+            cred1 == cred2
+        })
+        .unwrap();
+    processor_group
+        .merge_staged_commit(&processor.provider, processed.into_staged_commit().unwrap())
+        .unwrap();
+
+    assert_groups_eq(committer_group, processor_group);
+}

--- a/tests/group_builder.rs
+++ b/tests/group_builder.rs
@@ -78,8 +78,8 @@ fn app_components(dictionary: &AppDataDictionary) -> Vec<ComponentId> {
     Vec::tls_deserialize_exact(bytes).unwrap()
 }
 
-/// Default behavior (no caller dictionary): both group contexts advertise the
-/// APQMLS component and carry the ApqInfo entry; SafeAAD is not required.
+/// Default behavior (no caller dictionary): both group contexts advertise the APQMLS component and
+/// carry the ApqInfo entry; SafeAAD is not required.
 #[test]
 fn default_dictionary() {
     let (_, group) = build_group(None, None);
@@ -94,8 +94,8 @@ fn default_dictionary() {
     }
 }
 
-/// A caller-provided dictionary entry survives the build and is merged with
-/// the APQMLS entries instead of being clobbered.
+/// A caller-provided dictionary entry survives the build and is merged with the APQMLS entries
+/// instead of being clobbered.
 #[test]
 fn caller_dictionary_is_merged() {
     let safe_aad = ComponentId::from(ComponentType::SafeAad);
@@ -137,8 +137,8 @@ fn caller_app_components_are_merged() {
     assert!(components.contains(&APQMLS_COMPONENT_ID));
 }
 
-/// Extensions are per-group: a dictionary provided only for the T group does
-/// not leak into the PQ group.
+/// Extensions are per-group: a dictionary provided only for the T group does not leak into the PQ
+/// group.
 #[test]
 fn asymmetric_extensions() {
     let safe_aad = ComponentId::from(ComponentType::SafeAad);
@@ -155,8 +155,8 @@ fn asymmetric_extensions() {
     }
 }
 
-/// The caller entry survives a commit: the commit-path dictionary updater must
-/// produce only the ApqInfo delta, leaving foreign entries in place.
+/// The caller entry survives a commit: the commit-path dictionary updater must produce only the
+/// ApqInfo delta, leaving foreign entries in place.
 #[test]
 fn caller_entry_survives_commit() {
     let safe_aad = ComponentId::from(ComponentType::SafeAad);
@@ -220,8 +220,8 @@ fn assert_joiner_inherited_dictionary(alice_group: &ApqMlsGroup, bob_group: &Apq
     }
 }
 
-/// A joiner via `ApqMlsGroup::new_from_welcome` inherits the creator's merged
-/// dictionary (incl. the SafeAad entry) through the welcome.
+/// A joiner via `ApqMlsGroup::new_from_welcome` inherits the creator's merged dictionary (incl. the
+/// SafeAad entry) through the welcome.
 #[test]
 fn joiner_inherits_dictionary_via_new_from_welcome() {
     let safe_aad = ComponentId::from(ComponentType::SafeAad);
@@ -249,9 +249,8 @@ fn joiner_inherits_dictionary_via_new_from_welcome() {
     assert_group_operational(&alice, &mut alice_group, &bob, &mut bob_group);
 }
 
-/// Verifies the joined group is fully operational, beyond context contents:
-/// shared group state, correct membership, and commits flowing in both
-/// directions after the join.
+/// Verifies the joined group is fully operational, beyond context contents: shared group state,
+/// correct membership, and commits flowing in both directions after the join.
 fn assert_group_operational(
     alice: &Client<OpenMlsRustCrypto>,
     alice_group: &mut ApqMlsGroup,
@@ -273,8 +272,8 @@ fn assert_group_operational(
         assert_eq!(group.pq_group().members().count(), 2);
     }
 
-    // Epoch secrets agree (this is what proves the joiner's PSK derivation
-    // between the PQ and T joins actually worked).
+    // Epoch secrets agree (this is what proves the joiner's PSK derivation between the PQ and T
+    // joins actually worked).
     assert_groups_eq(alice_group, bob_group);
 
     // Bob commits a self-update; Alice processes and merges it.
@@ -283,16 +282,11 @@ fn assert_group_operational(
     commit_and_process(alice, alice_group, bob, bob_group);
 
     // The SafeAad requirement survived both post-join commits.
-    assert!(
-        bob_group
-            .t_group
-            .export_group_context()
-            .safe_aad_required()
-    );
+    assert!(bob_group.t_group.export_group_context().safe_aad_required());
 }
 
-/// `committer` creates and merges a self-update commit; `processor` processes
-/// and merges it. Asserts both views agree afterwards.
+/// `committer` creates and merges a self-update commit; `processor` processes and merges it.
+/// Asserts both views agree afterwards.
 fn commit_and_process(
     committer: &Client<OpenMlsRustCrypto>,
     committer_group: &mut ApqMlsGroup,


### PR DESCRIPTION
Add CommitBuilder::from_groups, a free process_message function, and
JoinBuilder to allow callers that manage raw MlsGroup pairs directly.
Generalize ApqSigner with associated types and expose split/new/accessor
methods on message types for sans-io integration patterns.